### PR TITLE
Tighten web_explore follow-up behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc -p tsconfig.json",
     "test": "vitest run --coverage",
     "test:watch": "vitest",
-    "lint": "tsc -p tsconfig.json --noEmit"
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "eval:live": "npm run build && node dist/scripts/live-web-eval.js"
   },
   "pi": {
     "extensions": [

--- a/scripts/live-web-eval.ts
+++ b/scripts/live-web-eval.ts
@@ -1,0 +1,379 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {
+  AuthStorage,
+  createAgentSession,
+  ModelRegistry,
+  SessionManager
+} from '@mariozechner/pi-coding-agent';
+
+type PromptCase = {
+  id: 'prompt-1' | 'prompt-2' | 'prompt-4';
+  title: string;
+  prompt: string;
+};
+
+type ToolCallRecord = {
+  toolName: string;
+  args: unknown;
+  startedAt: string;
+  endedAt?: string;
+  isError?: boolean;
+  result?: unknown;
+};
+
+type PromptMetrics = {
+  webExploreUsed: boolean;
+  webExploreFirstWebTool: boolean;
+  totalToolCalls: number;
+  totalWebToolCalls: number;
+  searchCalls: number;
+  fetchCalls: number;
+  headlessCalls: number;
+  lowLevelCallsAfterExplore: number;
+  emptySearches: number;
+  unsupportedFetches: number;
+  botCheckHeadlesses: number;
+};
+
+type PromptEvaluation = {
+  id: PromptCase['id'];
+  title: string;
+  prompt: string;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  finalAnswer: string;
+  toolCalls: ToolCallRecord[];
+  metrics: PromptMetrics;
+  verdict: 'pass' | 'mixed' | 'fail';
+  notes: string[];
+};
+
+type EvaluationRun = {
+  startedAt: string;
+  finishedAt: string;
+  cwd: string;
+  prompts: PromptEvaluation[];
+};
+
+const PROMPTS: PromptCase[] = [
+  {
+    id: 'prompt-1',
+    title: 'Playwright installed browser guidance',
+    prompt:
+      'Find current docs or discussions about Playwright launching an installed Chrome or Edge executable instead of a bundled browser, then summarize the recommended approach.'
+  },
+  {
+    id: 'prompt-2',
+    title: 'Vitest coverage configuration',
+    prompt:
+      'Find the current Vitest coverage docs and tell me how to enable coverage with the V8 provider in a TypeScript project.'
+  },
+  {
+    id: 'prompt-4',
+    title: 'DuckDuckGo HTML scraping pitfalls',
+    prompt:
+      'Find two or three current sources on DuckDuckGo HTML scraping in Node.js and tell me what the common parsing pitfalls are.'
+  }
+];
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function safeFileStamp(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+function extractText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return '';
+
+  if (Array.isArray(value)) {
+    return value.map(extractText).filter(Boolean).join('\n');
+  }
+
+  const record = value as Record<string, unknown>;
+
+  if (typeof record.text === 'string') return record.text;
+  if (typeof record.content === 'string') return record.content;
+
+  if (Array.isArray(record.content)) {
+    return record.content
+      .map((item) => {
+        if (!item || typeof item !== 'object') return '';
+        const contentItem = item as Record<string, unknown>;
+        return typeof contentItem.text === 'string' ? contentItem.text : '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  const nestedMessage = record.message;
+  if (nestedMessage && typeof nestedMessage === 'object') {
+    const nestedRecord = nestedMessage as Record<string, unknown>;
+    if (Array.isArray(nestedRecord.content)) {
+      return extractText(nestedMessage);
+    }
+  }
+
+  return '';
+}
+
+function toolDetails(result: unknown): unknown {
+  if (!result || typeof result !== 'object') return result;
+  const record = result as Record<string, unknown>;
+  return record.details ?? result;
+}
+
+function isEmptySearchResult(result: unknown): boolean {
+  const details = toolDetails(result);
+  if (!details || typeof details !== 'object') return false;
+  const record = details as Record<string, unknown>;
+  return record.status === 'ok' && Array.isArray(record.results) && record.results.length === 0;
+}
+
+function isUnsupportedFetchResult(result: unknown): boolean {
+  const details = toolDetails(result);
+  return !!details && typeof details === 'object' && (details as Record<string, unknown>).status === 'unsupported';
+}
+
+function isBotCheckHeadlessResult(result: unknown): boolean {
+  const details = toolDetails(result);
+  if (!details || typeof details !== 'object') return false;
+  const record = details as Record<string, unknown>;
+  const content = record.content;
+  const text = extractText(content);
+  const title =
+    content && typeof content === 'object' && !Array.isArray(content)
+      ? String((content as Record<string, unknown>).title ?? '')
+      : '';
+
+  return /just a moment|security verification|verify you are not a bot/i.test(`${title}\n${text}`);
+}
+
+function buildMetrics(toolCalls: ToolCallRecord[]): PromptMetrics {
+  const webToolNames = new Set(['web_explore', 'web_search', 'web_fetch', 'web_fetch_headless']);
+  const lowLevelWebToolNames = new Set(['web_search', 'web_fetch', 'web_fetch_headless']);
+  const webToolCalls = toolCalls.filter((call) => webToolNames.has(call.toolName));
+  const firstWebTool = webToolCalls[0];
+  const firstWebExploreIndex = toolCalls.findIndex((call) => call.toolName === 'web_explore');
+
+  return {
+    webExploreUsed: firstWebExploreIndex !== -1,
+    webExploreFirstWebTool: firstWebTool?.toolName === 'web_explore',
+    totalToolCalls: toolCalls.length,
+    totalWebToolCalls: webToolCalls.length,
+    searchCalls: toolCalls.filter((call) => call.toolName === 'web_search').length,
+    fetchCalls: toolCalls.filter((call) => call.toolName === 'web_fetch').length,
+    headlessCalls: toolCalls.filter((call) => call.toolName === 'web_fetch_headless').length,
+    lowLevelCallsAfterExplore:
+      firstWebExploreIndex === -1
+        ? toolCalls.filter((call) => lowLevelWebToolNames.has(call.toolName)).length
+        : toolCalls
+            .slice(firstWebExploreIndex + 1)
+            .filter((call) => lowLevelWebToolNames.has(call.toolName)).length,
+    emptySearches: toolCalls.filter((call) => call.toolName === 'web_search' && isEmptySearchResult(call.result)).length,
+    unsupportedFetches: toolCalls.filter(
+      (call) =>
+        (call.toolName === 'web_fetch' || call.toolName === 'web_fetch_headless') &&
+        isUnsupportedFetchResult(call.result)
+    ).length,
+    botCheckHeadlesses: toolCalls.filter(
+      (call) => call.toolName === 'web_fetch_headless' && isBotCheckHeadlessResult(call.result)
+    ).length
+  };
+}
+
+function evaluateVerdict(metrics: PromptMetrics, finalAnswer: string): {
+  verdict: 'pass' | 'mixed' | 'fail';
+  notes: string[];
+} {
+  const notes: string[] = [];
+
+  if (!metrics.webExploreUsed) {
+    notes.push('web_explore was not used');
+    return { verdict: 'fail', notes };
+  }
+
+  if (!metrics.webExploreFirstWebTool) {
+    notes.push('web_explore was not the first web research tool');
+  }
+
+  if (metrics.lowLevelCallsAfterExplore > 2) {
+    notes.push(`too many low-level calls after web_explore (${metrics.lowLevelCallsAfterExplore})`);
+  }
+
+  if (metrics.emptySearches > 0) {
+    notes.push(`empty web_search calls observed (${metrics.emptySearches})`);
+  }
+
+  if (metrics.botCheckHeadlesses > 0) {
+    notes.push(`headless bot-check pages observed (${metrics.botCheckHeadlesses})`);
+  }
+
+  if (!finalAnswer.trim()) {
+    notes.push('final answer text was empty');
+    return { verdict: 'fail', notes };
+  }
+
+  const looksClean =
+    metrics.webExploreFirstWebTool &&
+    metrics.lowLevelCallsAfterExplore <= 1 &&
+    metrics.emptySearches === 0 &&
+    metrics.botCheckHeadlesses === 0;
+
+  if (looksClean) {
+    return { verdict: 'pass', notes };
+  }
+
+  return { verdict: 'mixed', notes };
+}
+
+function formatMarkdown(run: EvaluationRun): string {
+  const sections = run.prompts
+    .map((prompt) => {
+      const tools = prompt.toolCalls
+        .map((call, index) => `  ${index + 1}. ${call.toolName}`)
+        .join('\n');
+
+      const notes = prompt.notes.length > 0 ? prompt.notes.map((note) => `- ${note}`).join('\n') : '- none';
+
+      return `## ${prompt.title}\n\n` +
+        `Prompt: ${prompt.prompt}\n\n` +
+        `Verdict: **${prompt.verdict}**\n\n` +
+        `Metrics:\n` +
+        `- web_explore used: ${prompt.metrics.webExploreUsed}\n` +
+        `- web_explore first web tool: ${prompt.metrics.webExploreFirstWebTool}\n` +
+        `- total tool calls: ${prompt.metrics.totalToolCalls}\n` +
+        `- total web tool calls: ${prompt.metrics.totalWebToolCalls}\n` +
+        `- web_search calls: ${prompt.metrics.searchCalls}\n` +
+        `- web_fetch calls: ${prompt.metrics.fetchCalls}\n` +
+        `- web_fetch_headless calls: ${prompt.metrics.headlessCalls}\n` +
+        `- low-level calls after web_explore: ${prompt.metrics.lowLevelCallsAfterExplore}\n` +
+        `- empty searches: ${prompt.metrics.emptySearches}\n` +
+        `- unsupported fetches: ${prompt.metrics.unsupportedFetches}\n` +
+        `- bot-check headlesses: ${prompt.metrics.botCheckHeadlesses}\n\n` +
+        `Tool order:\n${tools || '  none'}\n\n` +
+        `Notes:\n${notes}\n\n` +
+        `Final answer:\n\n${prompt.finalAnswer.trim() || '(empty)'}\n`;
+    })
+    .join('\n---\n\n');
+
+  return `# live web eval\n\nStarted: ${run.startedAt}\nFinished: ${run.finishedAt}\nCWD: ${run.cwd}\n\n${sections}`;
+}
+
+async function runPrompt(promptCase: PromptCase, cwd: string, authStorage: AuthStorage, modelRegistry: ModelRegistry) {
+  const startedAt = Date.now();
+  const toolCalls: ToolCallRecord[] = [];
+  let finalAnswer = '';
+
+  const { session } = await createAgentSession({
+    cwd,
+    authStorage,
+    modelRegistry,
+    sessionManager: SessionManager.inMemory()
+  });
+
+  const unsubscribe = session.subscribe((event: any) => {
+    if (event.type === 'tool_execution_start') {
+      toolCalls.push({
+        toolName: event.toolName,
+        args: event.args,
+        startedAt: isoNow()
+      });
+    }
+
+    if (event.type === 'tool_execution_end') {
+      const active = [...toolCalls].reverse().find((call) => call.toolName === event.toolName && !call.endedAt);
+      if (active) {
+        active.endedAt = isoNow();
+        active.isError = !!event.isError;
+        active.result = event.result;
+      }
+    }
+
+    if (event.type === 'message_end' && event.message?.role === 'assistant') {
+      const text = extractText(event.message);
+      if (text.trim()) {
+        finalAnswer = text;
+      }
+    }
+  });
+
+  try {
+    await session.prompt(promptCase.prompt);
+
+    if (!finalAnswer.trim()) {
+      const reversedMessages = [...session.messages].reverse();
+      const lastAssistant = reversedMessages.find((message: any) => message?.role === 'assistant');
+      finalAnswer = lastAssistant ? extractText(lastAssistant) : '';
+    }
+  } finally {
+    unsubscribe();
+    session.dispose();
+  }
+
+  const finishedAt = Date.now();
+  const metrics = buildMetrics(toolCalls);
+  const evaluation = evaluateVerdict(metrics, finalAnswer);
+
+  return {
+    id: promptCase.id,
+    title: promptCase.title,
+    prompt: promptCase.prompt,
+    startedAt: new Date(startedAt).toISOString(),
+    finishedAt: new Date(finishedAt).toISOString(),
+    durationMs: finishedAt - startedAt,
+    finalAnswer,
+    toolCalls,
+    metrics,
+    verdict: evaluation.verdict,
+    notes: evaluation.notes
+  } satisfies PromptEvaluation;
+}
+
+async function main() {
+  const cwd = process.cwd();
+  const startedAt = isoNow();
+  const authStorage = AuthStorage.create();
+  const modelRegistry = ModelRegistry.create(authStorage);
+
+  const prompts: PromptEvaluation[] = [];
+  for (const promptCase of PROMPTS) {
+    console.log(`Running ${promptCase.id}: ${promptCase.title}`);
+    prompts.push(await runPrompt(promptCase, cwd, authStorage, modelRegistry));
+  }
+
+  const run: EvaluationRun = {
+    startedAt,
+    finishedAt: isoNow(),
+    cwd,
+    prompts
+  };
+
+  const outputDir = path.join(cwd, 'local_docs', 'tmp', 'live-evals');
+  await mkdir(outputDir, { recursive: true });
+
+  const stamp = safeFileStamp();
+  const jsonPath = path.join(outputDir, `${stamp}.json`);
+  const mdPath = path.join(outputDir, `${stamp}.md`);
+
+  await writeFile(jsonPath, `${JSON.stringify(run, null, 2)}\n`, 'utf8');
+  await writeFile(mdPath, `${formatMarkdown(run)}\n`, 'utf8');
+
+  console.log(`\nSaved JSON: ${jsonPath}`);
+  console.log(`Saved Markdown: ${mdPath}`);
+
+  for (const prompt of run.prompts) {
+    console.log(`\n${prompt.id} -> ${prompt.verdict}`);
+    console.log(`  web_explore first web tool: ${prompt.metrics.webExploreFirstWebTool}`);
+    console.log(`  low-level calls after web_explore: ${prompt.metrics.lowLevelCallsAfterExplore}`);
+    console.log(`  empty searches: ${prompt.metrics.emptySearches}`);
+    console.log(`  bot-check headlesses: ${prompt.metrics.botCheckHeadlesses}`);
+  }
+}
+
+await main();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,9 @@ export default function extension(pi: ExtensionAPI) {
     systemPrompt:
       `${event.systemPrompt}\n\n` +
       'For web research questions that require finding and comparing multiple sources, prefer web_explore. ' +
-      'Use web_search, web_fetch, and web_fetch_headless for direct/manual operations like explicit search calls, specific URL reads, or debugging.'
+      'Use web_search, web_fetch, and web_fetch_headless for direct/manual operations like explicit search calls, specific URL reads, or debugging. ' +
+      'After using web_explore, only call low-level web tools if there is a specific unresolved gap. ' +
+      'Do not keep searching or fetching just for extra confirmation.'
   }));
 
   pi.registerTool({
@@ -76,7 +78,7 @@ export default function extension(pi: ExtensionAPI) {
     name: 'web_explore',
     label: 'Web Explore',
     description:
-      'Research a web question using bounded search/fetch passes, source ranking, and targeted headless escalation. Prefer this for multi-source web research, current docs/discussion lookups, and recommendation summaries.',
+      'Research a web question using bounded search/fetch passes, source ranking, and targeted headless escalation. Prefer this for multi-source web research, current docs/discussion lookups, and recommendation summaries. Use this instead of chaining low-level web tools for the same research task.',
     parameters: Type.Object({
       query: Type.String({ description: 'Web research question to explore.' })
     }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,15 +10,46 @@ export default function extension(pi: ExtensionAPI) {
   const webFetch = createWebFetchTool();
   const webFetchHeadless = createWebFetchHeadlessTool();
   const webExplore = createWebExploreTool();
+  let usedWebExploreThisPrompt = false;
 
-  pi.on('before_agent_start', async (event) => ({
-    systemPrompt:
-      `${event.systemPrompt}\n\n` +
-      'For web research questions that require finding and comparing multiple sources, prefer web_explore. ' +
-      'Use web_search, web_fetch, and web_fetch_headless for direct/manual operations like explicit search calls, specific URL reads, or debugging. ' +
-      'After using web_explore, only call low-level web tools if there is a specific unresolved gap. ' +
-      'Do not keep searching or fetching just for extra confirmation.'
-  }));
+  pi.on('before_agent_start', async (event) => {
+    usedWebExploreThisPrompt = false;
+    return {
+      systemPrompt:
+        `${event.systemPrompt}\n\n` +
+        'For web research questions that require finding and comparing multiple sources, prefer web_explore. ' +
+        'Use web_search, web_fetch, and web_fetch_headless for direct/manual operations like explicit search calls, specific URL reads, or debugging. ' +
+        'After using web_explore, only call low-level web tools if there is a specific unresolved gap. ' +
+        'Do not keep searching or fetching just for extra confirmation.'
+    };
+  });
+
+  pi.on('tool_execution_end', async (event) => {
+    if (event.toolName === 'web_explore' && !event.isError) {
+      usedWebExploreThisPrompt = true;
+    }
+  });
+
+  pi.on('agent_end', async () => {
+    usedWebExploreThisPrompt = false;
+  });
+
+  (pi as any).on('context', async (event: { messages: Array<{ role: string; content: string }> }) => {
+    if (!usedWebExploreThisPrompt) {
+      return { messages: event.messages };
+    }
+
+    return {
+      messages: [
+        ...event.messages,
+        {
+          role: 'user',
+          content:
+            'web_explore has already been used for this research task. Only call low-level web tools if there is a specific unresolved gap. Do not keep searching or fetching just for extra confirmation.'
+        }
+      ]
+    };
+  });
 
   pi.registerTool({
     name: 'web_search',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,15 +5,36 @@ import { createWebFetchTool } from './tools/web-fetch.js';
 import { createWebFetchHeadlessTool } from './tools/web-fetch-headless.js';
 import { createWebSearchTool } from './tools/web-search.js';
 
+const WEB_EXPLORE_REMINDER_TYPE = 'pi-web-agent-web-explore-reminder';
+const WEB_EXPLORE_REMINDER =
+  'web_explore has already been used for this research task. Only call low-level web tools if there is a specific unresolved gap. Do not keep searching or fetching just for extra confirmation.';
+
+type ContextMessage = {
+  role: string;
+  toolName?: string;
+  isError?: boolean;
+  customType?: string;
+  content?: unknown;
+  timestamp?: number;
+};
+
+function hasSuccessfulWebExplore(messages: ContextMessage[]) {
+  return messages.some((message) => message.role === 'toolResult' && message.toolName === 'web_explore' && !message.isError);
+}
+
+function hasWebExploreReminder(messages: ContextMessage[]) {
+  return messages.some(
+    (message) => message.role === 'custom' && message.customType === WEB_EXPLORE_REMINDER_TYPE
+  );
+}
+
 export default function extension(pi: ExtensionAPI) {
   const webSearch = createWebSearchTool();
   const webFetch = createWebFetchTool();
   const webFetchHeadless = createWebFetchHeadlessTool();
   const webExplore = createWebExploreTool();
-  let usedWebExploreThisPrompt = false;
 
   pi.on('before_agent_start', async (event) => {
-    usedWebExploreThisPrompt = false;
     return {
       systemPrompt:
         `${event.systemPrompt}\n\n` +
@@ -24,18 +45,8 @@ export default function extension(pi: ExtensionAPI) {
     };
   });
 
-  pi.on('tool_execution_end', async (event) => {
-    if (event.toolName === 'web_explore' && !event.isError) {
-      usedWebExploreThisPrompt = true;
-    }
-  });
-
-  pi.on('agent_end', async () => {
-    usedWebExploreThisPrompt = false;
-  });
-
-  (pi as any).on('context', async (event: { messages: Array<{ role: string; content: string }> }) => {
-    if (!usedWebExploreThisPrompt) {
+  (pi as any).on('context', async (event: { messages: ContextMessage[] }) => {
+    if (!hasSuccessfulWebExplore(event.messages) || hasWebExploreReminder(event.messages)) {
       return { messages: event.messages };
     }
 
@@ -43,9 +54,11 @@ export default function extension(pi: ExtensionAPI) {
       messages: [
         ...event.messages,
         {
-          role: 'user',
-          content:
-            'web_explore has already been used for this research task. Only call low-level web tools if there is a specific unresolved gap. Do not keep searching or fetching just for extra confirmation.'
+          role: 'custom',
+          customType: WEB_EXPLORE_REMINDER_TYPE,
+          content: WEB_EXPLORE_REMINDER,
+          display: false,
+          timestamp: Date.now()
         }
       ]
     };

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -29,6 +29,7 @@ describe('Pi extension entrypoint', () => {
     expect(webExplore).toBeDefined();
     expect(webExplore.description).toContain('Prefer this for multi-source web research');
     expect(webExplore.description).toContain('current docs/discussion lookups');
+    expect(webExplore.description).toContain('Use this instead of chaining low-level web tools');
     expect(webExplore.parameters.properties).toHaveProperty('query');
     expect(Object.keys(webExplore.parameters.properties)).toEqual(['query']);
   });
@@ -83,6 +84,8 @@ describe('Pi extension entrypoint', () => {
     expect(result.systemPrompt).toContain(
       'Use web_search, web_fetch, and web_fetch_headless for direct/manual operations'
     );
+    expect(result.systemPrompt).toContain('After using web_explore, only call low-level web tools if there is a specific unresolved gap');
+    expect(result.systemPrompt).toContain('Do not keep searching or fetching just for extra confirmation');
   });
 
   it('returns human-readable content for web_explore instead of only raw json', async () => {
@@ -101,5 +104,5 @@ describe('Pi extension entrypoint', () => {
 
     expect(result.content[0].text).toContain('Findings');
     expect(result.content[0].text).toContain('Sources');
-  });
+  }, 15000);
 });

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -88,6 +88,56 @@ describe('Pi extension entrypoint', () => {
     expect(result.systemPrompt).toContain('Do not keep searching or fetching just for extra confirmation');
   });
 
+  it('adds a post-web_explore context hint for later turns in the same prompt', async () => {
+    const handlers = new Map<string, Function>();
+    const pi = {
+      registerTool: vi.fn(),
+      on: vi.fn((eventName: string, handler: Function) => {
+        handlers.set(eventName, handler);
+      })
+    };
+
+    extension(pi as never);
+
+    const beforeAgentStart = handlers.get('before_agent_start');
+    const toolExecutionEnd = handlers.get('tool_execution_end');
+    const context = handlers.get('context');
+
+    expect(beforeAgentStart).toBeDefined();
+    expect(toolExecutionEnd).toBeDefined();
+    expect(context).toBeDefined();
+
+    await beforeAgentStart!(
+      {
+        prompt: 'Research something on the web',
+        images: [],
+        systemPrompt: 'Base system prompt'
+      },
+      {}
+    );
+
+    await toolExecutionEnd!(
+      {
+        toolName: 'web_explore',
+        result: { details: { status: 'ok' } },
+        isError: false
+      },
+      {}
+    );
+
+    const result = await context!(
+      {
+        messages: [{ role: 'user', content: 'Original research prompt' }]
+      },
+      {}
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[1].content).toContain('web_explore has already been used for this research task');
+    expect(result.messages[1].content).toContain('specific unresolved gap');
+    expect(result.messages[1].content).toContain('Do not keep searching or fetching just for extra confirmation');
+  });
+
   it('returns human-readable content for web_explore instead of only raw json', async () => {
     const tools: any[] = [];
     const pi = {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -88,7 +88,7 @@ describe('Pi extension entrypoint', () => {
     expect(result.systemPrompt).toContain('Do not keep searching or fetching just for extra confirmation');
   });
 
-  it('adds a post-web_explore context hint for later turns in the same prompt', async () => {
+  it('adds a post-web_explore context hint based on conversation messages instead of shared mutable state', async () => {
     const handlers = new Map<string, Function>();
     const pi = {
       registerTool: vi.fn(),
@@ -99,43 +99,109 @@ describe('Pi extension entrypoint', () => {
 
     extension(pi as never);
 
-    const beforeAgentStart = handlers.get('before_agent_start');
-    const toolExecutionEnd = handlers.get('tool_execution_end');
     const context = handlers.get('context');
-
-    expect(beforeAgentStart).toBeDefined();
-    expect(toolExecutionEnd).toBeDefined();
     expect(context).toBeDefined();
-
-    await beforeAgentStart!(
-      {
-        prompt: 'Research something on the web',
-        images: [],
-        systemPrompt: 'Base system prompt'
-      },
-      {}
-    );
-
-    await toolExecutionEnd!(
-      {
-        toolName: 'web_explore',
-        result: { details: { status: 'ok' } },
-        isError: false
-      },
-      {}
-    );
 
     const result = await context!(
       {
-        messages: [{ role: 'user', content: 'Original research prompt' }]
+        messages: [
+          { role: 'user', content: 'Original research prompt' },
+          {
+            role: 'toolResult',
+            toolCallId: 'tool-call-1',
+            toolName: 'web_explore',
+            content: [{ type: 'text', text: 'Findings\n- Source A' }],
+            details: { status: 'ok' },
+            isError: false,
+            timestamp: Date.now()
+          }
+        ]
+      },
+      {}
+    );
+
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[2].role).toBe('custom');
+    expect(result.messages[2].content).toContain('web_explore has already been used for this research task');
+    expect(result.messages[2].content).toContain('specific unresolved gap');
+    expect(result.messages[2].content).toContain('Do not keep searching or fetching just for extra confirmation');
+  });
+
+  it('does not inject the reminder as a fake user message', async () => {
+    const handlers = new Map<string, Function>();
+    const pi = {
+      registerTool: vi.fn(),
+      on: vi.fn((eventName: string, handler: Function) => {
+        handlers.set(eventName, handler);
+      })
+    };
+
+    extension(pi as never);
+
+    const context = handlers.get('context');
+    expect(context).toBeDefined();
+
+    const result = await context!(
+      {
+        messages: [
+          {
+            role: 'toolResult',
+            toolCallId: 'tool-call-1',
+            toolName: 'web_explore',
+            content: [{ type: 'text', text: 'Findings\n- Source A' }],
+            details: { status: 'ok' },
+            isError: false,
+            timestamp: Date.now()
+          }
+        ]
+      },
+      {}
+    );
+
+    expect(result.messages.some((message: { role: string }) => message.role === 'user')).toBe(false);
+    expect(result.messages.at(-1)?.role).toBe('custom');
+  });
+
+  it('does not add duplicate reminders when one is already present in context', async () => {
+    const handlers = new Map<string, Function>();
+    const pi = {
+      registerTool: vi.fn(),
+      on: vi.fn((eventName: string, handler: Function) => {
+        handlers.set(eventName, handler);
+      })
+    };
+
+    extension(pi as never);
+
+    const context = handlers.get('context');
+    expect(context).toBeDefined();
+
+    const result = await context!(
+      {
+        messages: [
+          {
+            role: 'toolResult',
+            toolCallId: 'tool-call-1',
+            toolName: 'web_explore',
+            content: [{ type: 'text', text: 'Findings\n- Source A' }],
+            details: { status: 'ok' },
+            isError: false,
+            timestamp: Date.now()
+          },
+          {
+            role: 'custom',
+            customType: 'pi-web-agent-web-explore-reminder',
+            content:
+              'web_explore has already been used for this research task. Only call low-level web tools if there is a specific unresolved gap. Do not keep searching or fetching just for extra confirmation.',
+            display: false,
+            timestamp: Date.now()
+          }
+        ]
       },
       {}
     );
 
     expect(result.messages).toHaveLength(2);
-    expect(result.messages[1].content).toContain('web_explore has already been used for this research task');
-    expect(result.messages[1].content).toContain('specific unresolved gap');
-    expect(result.messages[1].content).toContain('Do not keep searching or fetching just for extra confirmation');
   });
 
   it('returns human-readable content for web_explore instead of only raw json', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "types": ["vitest/globals", "node"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
-      reportsDirectory: 'coverage'
+      reportsDirectory: 'coverage',
+      exclude: ['scripts/**', 'dist/**', '.pi/**', 'vitest.config.ts']
     }
   }
 });


### PR DESCRIPTION
This tightens the web research path so the model is less likely to keep chaining low-level web tools after web_explore already did the main job.

Also added an opt-in live eval harness for Prompt 1 / 2 / 4 so we can measure tool order and churn instead of eyeballing it every time.

The latest eval run on this branch landed at:
- Prompt 1: pass
- Prompt 2: pass
- Prompt 4: mixed

So the high-signal prompts are in a good place now, and the remaining rough edge is mostly the harder multi-source DuckDuckGo case.