### PR TITLE
fix search failures and rein in post-web_explore churn

### DIFF
--- a/scripts/live-web-eval.ts
+++ b/scripts/live-web-eval.ts
@@ -55,6 +55,7 @@ type PromptMetrics = {
   fetchCalls: number;
   headlessCalls: number;
   lowLevelCallsAfterExplore: number;
+  guardedLowLevelCallsAfterExplore: number;
   emptySearches: number;
   unsupportedFetches: number;
   botCheckHeadlesses: number;
@@ -237,6 +238,15 @@ function isBotCheckHeadlessResult(result: unknown): boolean {
   return /just a moment|security verification|verify you are not a bot/i.test(`${title}\n${text}`);
 }
 
+function isPostWebExploreGuardResult(result: unknown): boolean {
+  const details = toolDetails(result);
+  if (!details || typeof details !== 'object') return false;
+  const record = details as Record<string, unknown>;
+  const error = record.error;
+  if (!error || typeof error !== 'object') return false;
+  return (error as Record<string, unknown>).code === 'POST_WEB_EXPLORE_GUARD';
+}
+
 function buildMetrics(toolCalls: ToolCallRecord[]): PromptMetrics {
   const webToolNames = new Set(['web_explore', 'web_search', 'web_fetch', 'web_fetch_headless']);
   const lowLevelWebToolNames = new Set(['web_search', 'web_fetch', 'web_fetch_headless']);
@@ -254,10 +264,24 @@ function buildMetrics(toolCalls: ToolCallRecord[]): PromptMetrics {
     headlessCalls: toolCalls.filter((call) => call.toolName === 'web_fetch_headless').length,
     lowLevelCallsAfterExplore:
       firstWebExploreIndex === -1
-        ? toolCalls.filter((call) => lowLevelWebToolNames.has(call.toolName)).length
+        ? toolCalls.filter(
+            (call) => lowLevelWebToolNames.has(call.toolName) && !isPostWebExploreGuardResult(call.result)
+          ).length
         : toolCalls
             .slice(firstWebExploreIndex + 1)
-            .filter((call) => lowLevelWebToolNames.has(call.toolName)).length,
+            .filter(
+              (call) => lowLevelWebToolNames.has(call.toolName) && !isPostWebExploreGuardResult(call.result)
+            ).length,
+    guardedLowLevelCallsAfterExplore:
+      firstWebExploreIndex === -1
+        ? toolCalls.filter(
+            (call) => lowLevelWebToolNames.has(call.toolName) && isPostWebExploreGuardResult(call.result)
+          ).length
+        : toolCalls
+            .slice(firstWebExploreIndex + 1)
+            .filter(
+              (call) => lowLevelWebToolNames.has(call.toolName) && isPostWebExploreGuardResult(call.result)
+            ).length,
     emptySearches: toolCalls.filter((call) => call.toolName === 'web_search' && isEmptySearchResult(call.result)).length,
     unsupportedFetches: toolCalls.filter(
       (call) =>
@@ -358,6 +382,7 @@ function formatMarkdown(run: EvaluationRun): string {
         `- web_fetch calls: ${prompt.metrics.fetchCalls}\n` +
         `- web_fetch_headless calls: ${prompt.metrics.headlessCalls}\n` +
         `- low-level calls after web_explore: ${prompt.metrics.lowLevelCallsAfterExplore}\n` +
+        `- guarded low-level calls after web_explore: ${prompt.metrics.guardedLowLevelCallsAfterExplore}\n` +
         `- empty searches: ${prompt.metrics.emptySearches}\n` +
         `- unsupported fetches: ${prompt.metrics.unsupportedFetches}\n` +
         `- bot-check headlesses: ${prompt.metrics.botCheckHeadlesses}\n\n` +
@@ -536,6 +561,7 @@ async function main() {
     console.log(`\n${prompt.id} -> ${prompt.verdict}`);
     console.log(`  web_explore first web tool: ${prompt.metrics.webExploreFirstWebTool}`);
     console.log(`  low-level calls after web_explore: ${prompt.metrics.lowLevelCallsAfterExplore}`);
+    console.log(`  guarded low-level calls after web_explore: ${prompt.metrics.guardedLowLevelCallsAfterExplore}`);
     console.log(`  empty searches: ${prompt.metrics.emptySearches}`);
     console.log(`  bot-check headlesses: ${prompt.metrics.botCheckHeadlesses}`);
   }

--- a/scripts/live-web-eval.ts
+++ b/scripts/live-web-eval.ts
@@ -7,11 +7,34 @@ import {
   ModelRegistry,
   SessionManager
 } from '@mariozechner/pi-coding-agent';
+import { createWebSearchTool } from '../src/tools/web-search.js';
 
 type PromptCase = {
   id: 'prompt-1' | 'prompt-2' | 'prompt-4';
   title: string;
   prompt: string;
+};
+
+type SearchFailureCase = {
+  id: 'no-results' | 'parse-failed' | 'blocked-html' | 'fetch-failed';
+  title: string;
+  expectedCode: string;
+  expectedMessage: string;
+  searchHtml: (query: string) => Promise<string>;
+};
+
+type SearchFailureEvaluation = {
+  id: SearchFailureCase['id'];
+  title: string;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  expectedCode: string;
+  actualCode: string;
+  expectedMessage: string;
+  actualMessage: string;
+  verdict: 'pass' | 'fail';
+  notes: string[];
 };
 
 type ToolCallRecord = {
@@ -56,6 +79,7 @@ type EvaluationRun = {
   finishedAt: string;
   cwd: string;
   prompts: PromptEvaluation[];
+  searchFailureCases: SearchFailureEvaluation[];
 };
 
 const PROMPTS: PromptCase[] = [
@@ -76,6 +100,65 @@ const PROMPTS: PromptCase[] = [
     title: 'DuckDuckGo HTML scraping pitfalls',
     prompt:
       'Find two or three current sources on DuckDuckGo HTML scraping in Node.js and tell me what the common parsing pitfalls are.'
+  }
+];
+
+const SEARCH_FAILURE_CASES: SearchFailureCase[] = [
+  {
+    id: 'no-results',
+    title: 'NO_RESULTS classification',
+    expectedCode: 'NO_RESULTS',
+    expectedMessage: 'DuckDuckGo returned no usable results for this query.',
+    searchHtml: async () => `
+      <html>
+        <body>
+          <div class="results">
+            <div class="no-results">No results found for your search.</div>
+          </div>
+        </body>
+      </html>
+    `
+  },
+  {
+    id: 'parse-failed',
+    title: 'PARSE_FAILED classification',
+    expectedCode: 'PARSE_FAILED',
+    expectedMessage: 'DuckDuckGo returned a page, but it did not match the expected results format.',
+    searchHtml: async () => `
+      <html>
+        <body>
+          <main>
+            <h1>Unexpected page</h1>
+            <p>Nothing here looks like a search results page.</p>
+          </main>
+        </body>
+      </html>
+    `
+  },
+  {
+    id: 'blocked-html',
+    title: 'BLOCKED classification from challenge HTML',
+    expectedCode: 'BLOCKED',
+    expectedMessage: 'DuckDuckGo search appears to be blocked or rate limited.',
+    searchHtml: async () => `
+      <html>
+        <body>
+          <main>
+            <h1>Are you a robot?</h1>
+            <p>Please verify you are human to continue.</p>
+          </main>
+        </body>
+      </html>
+    `
+  },
+  {
+    id: 'fetch-failed',
+    title: 'FETCH_FAILED classification',
+    expectedCode: 'FETCH_FAILED',
+    expectedMessage: 'DuckDuckGo search request failed: socket hang up',
+    searchHtml: async () => {
+      throw new Error('socket hang up');
+    }
   }
 ];
 
@@ -232,6 +315,28 @@ function evaluateVerdict(metrics: PromptMetrics, finalAnswer: string): {
   return { verdict: 'mixed', notes };
 }
 
+function formatSearchFailureMarkdown(cases: SearchFailureEvaluation[]) {
+  if (cases.length === 0) {
+    return '## Search failure cases\n\nNone.\n';
+  }
+
+  const sections = cases
+    .map((testCase) => {
+      const notes = testCase.notes.length > 0 ? testCase.notes.map((note) => `- ${note}`).join('\n') : '- none';
+
+      return `### ${testCase.title}\n\n` +
+        `Verdict: **${testCase.verdict}**\n\n` +
+        `- expected code: ${testCase.expectedCode}\n` +
+        `- actual code: ${testCase.actualCode}\n` +
+        `- expected message: ${testCase.expectedMessage}\n` +
+        `- actual message: ${testCase.actualMessage}\n\n` +
+        `Notes:\n${notes}\n`;
+    })
+    .join('\n');
+
+  return `## Search failure cases\n\n${sections}`;
+}
+
 function formatMarkdown(run: EvaluationRun): string {
   const sections = run.prompts
     .map((prompt) => {
@@ -262,7 +367,30 @@ function formatMarkdown(run: EvaluationRun): string {
     })
     .join('\n---\n\n');
 
-  return `# live web eval\n\nStarted: ${run.startedAt}\nFinished: ${run.finishedAt}\nCWD: ${run.cwd}\n\n${sections}`;
+  return `# live web eval\n\nStarted: ${run.startedAt}\nFinished: ${run.finishedAt}\nCWD: ${run.cwd}\n\n` +
+    `${sections}\n\n---\n\n${formatSearchFailureMarkdown(run.searchFailureCases)}`;
+}
+
+function evaluateSearchFailureCase(
+  expectedCode: string,
+  actualCode: string,
+  expectedMessage: string,
+  actualMessage: string
+) {
+  const notes: string[] = [];
+
+  if (actualCode !== expectedCode) {
+    notes.push(`expected code ${expectedCode} but got ${actualCode}`);
+  }
+
+  if (actualMessage !== expectedMessage) {
+    notes.push(`expected message \"${expectedMessage}\" but got \"${actualMessage}\"`);
+  }
+
+  return {
+    verdict: notes.length === 0 ? 'pass' : 'fail',
+    notes
+  } as const;
 }
 
 async function runPrompt(promptCase: PromptCase, cwd: string, authStorage: AuthStorage, modelRegistry: ModelRegistry) {
@@ -335,6 +463,36 @@ async function runPrompt(promptCase: PromptCase, cwd: string, authStorage: AuthS
   } satisfies PromptEvaluation;
 }
 
+async function runSearchFailureCase(testCase: SearchFailureCase) {
+  const startedAt = Date.now();
+  const search = createWebSearchTool({ searchHtml: testCase.searchHtml });
+  const result = await search({ query: 'deterministic test query' });
+  const finishedAt = Date.now();
+
+  const actualCode = result.error?.code ?? 'NO_ERROR';
+  const actualMessage = result.error?.message ?? 'No error message returned.';
+  const evaluation = evaluateSearchFailureCase(
+    testCase.expectedCode,
+    actualCode,
+    testCase.expectedMessage,
+    actualMessage
+  );
+
+  return {
+    id: testCase.id,
+    title: testCase.title,
+    startedAt: new Date(startedAt).toISOString(),
+    finishedAt: new Date(finishedAt).toISOString(),
+    durationMs: finishedAt - startedAt,
+    expectedCode: testCase.expectedCode,
+    actualCode,
+    expectedMessage: testCase.expectedMessage,
+    actualMessage,
+    verdict: evaluation.verdict,
+    notes: evaluation.notes
+  } satisfies SearchFailureEvaluation;
+}
+
 async function main() {
   const cwd = process.cwd();
   const startedAt = isoNow();
@@ -347,11 +505,18 @@ async function main() {
     prompts.push(await runPrompt(promptCase, cwd, authStorage, modelRegistry));
   }
 
+  const searchFailureCases: SearchFailureEvaluation[] = [];
+  for (const testCase of SEARCH_FAILURE_CASES) {
+    console.log(`Running ${testCase.id}: ${testCase.title}`);
+    searchFailureCases.push(await runSearchFailureCase(testCase));
+  }
+
   const run: EvaluationRun = {
     startedAt,
     finishedAt: isoNow(),
     cwd,
-    prompts
+    prompts,
+    searchFailureCases
   };
 
   const outputDir = path.join(cwd, 'local_docs', 'tmp', 'live-evals');
@@ -373,6 +538,12 @@ async function main() {
     console.log(`  low-level calls after web_explore: ${prompt.metrics.lowLevelCallsAfterExplore}`);
     console.log(`  empty searches: ${prompt.metrics.emptySearches}`);
     console.log(`  bot-check headlesses: ${prompt.metrics.botCheckHeadlesses}`);
+  }
+
+  for (const testCase of run.searchFailureCases) {
+    console.log(`\n${testCase.id} -> ${testCase.verdict}`);
+    console.log(`  expected code: ${testCase.expectedCode}`);
+    console.log(`  actual code: ${testCase.actualCode}`);
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,8 +10,28 @@ export default function extension(pi: ExtensionAPI) {
   const webFetch = createWebFetchTool();
   const webFetchHeadless = createWebFetchHeadlessTool();
   const webExplore = createWebExploreTool();
+  let webExploreUsedInCurrentFlow = false;
+
+  function guardedLowLevelResponse() {
+    const result = {
+      status: 'error',
+      error: {
+        code: 'POST_WEB_EXPLORE_GUARD',
+        message:
+          'web_explore already ran for this research task. Only use low-level web tools if there is a specific unresolved gap.'
+      }
+    };
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      details: result,
+      isError: true
+    };
+  }
 
   pi.on('before_agent_start', async (event) => {
+    webExploreUsedInCurrentFlow = false;
+
     return {
       systemPrompt:
         `${event.systemPrompt}\n\n` +
@@ -32,6 +52,10 @@ export default function extension(pi: ExtensionAPI) {
       query: Type.String({ description: 'Search query.' })
     }),
     async execute(_toolCallId, params) {
+      if (webExploreUsedInCurrentFlow) {
+        return guardedLowLevelResponse();
+      }
+
       const result = await webSearch({ query: params.query });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
@@ -50,6 +74,10 @@ export default function extension(pi: ExtensionAPI) {
       url: Type.String({ description: 'HTTP or HTTPS URL to fetch.' })
     }),
     async execute(_toolCallId, params) {
+      if (webExploreUsedInCurrentFlow) {
+        return guardedLowLevelResponse();
+      }
+
       const result = await webFetch({ url: params.url });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
@@ -68,6 +96,10 @@ export default function extension(pi: ExtensionAPI) {
       url: Type.String({ description: 'HTTP or HTTPS URL to fetch in headless mode.' })
     }),
     async execute(_toolCallId, params) {
+      if (webExploreUsedInCurrentFlow) {
+        return guardedLowLevelResponse();
+      }
+
       const result = await webFetchHeadless({ url: params.url });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
@@ -87,6 +119,10 @@ export default function extension(pi: ExtensionAPI) {
     }),
     async execute(_toolCallId, params) {
       const result = await webExplore({ query: params.query });
+      if (result.status === 'ok') {
+        webExploreUsedInCurrentFlow = true;
+      }
+
       return {
         content: [
           {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { createWebExploreTool } from './tools/web-explore.js';
 import { createWebFetchTool } from './tools/web-fetch.js';
 import { createWebFetchHeadlessTool } from './tools/web-fetch-headless.js';
 import { createWebSearchTool } from './tools/web-search.js';
+import type { WebFetchHeadlessResponse, WebFetchResponse, WebSearchResponse } from './types.js';
 
 export default function extension(pi: ExtensionAPI) {
   const webSearch = createWebSearchTool();
@@ -11,21 +12,63 @@ export default function extension(pi: ExtensionAPI) {
   const webFetchHeadless = createWebFetchHeadlessTool();
   const webExplore = createWebExploreTool();
   let webExploreUsedInCurrentFlow = false;
+  const postWebExploreGuardError = {
+    code: 'POST_WEB_EXPLORE_GUARD',
+    message:
+      'web_explore already ran for this research task. Only use low-level web tools if there is a specific unresolved gap.'
+  };
 
-  function guardedLowLevelResponse() {
-    const result = {
+  function guardSearchResponse() {
+    const result: WebSearchResponse = {
       status: 'error',
-      error: {
-        code: 'POST_WEB_EXPLORE_GUARD',
-        message:
-          'web_explore already ran for this research task. Only use low-level web tools if there is a specific unresolved gap.'
-      }
+      results: [],
+      metadata: {
+        backend: 'duckduckgo',
+        cacheHit: false
+      },
+      error: postWebExploreGuardError
     };
 
     return {
-      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
       details: result,
-      isError: true
+      isError: true as const
+    };
+  }
+
+  function guardFetchResponse(url: string) {
+    const result: WebFetchResponse = {
+      status: 'error',
+      url,
+      metadata: {
+        method: 'http',
+        cacheHit: false
+      },
+      error: postWebExploreGuardError
+    };
+
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      details: result,
+      isError: true as const
+    };
+  }
+
+  function guardHeadlessResponse(url: string) {
+    const result: WebFetchHeadlessResponse = {
+      status: 'error',
+      url,
+      metadata: {
+        method: 'headless',
+        cacheHit: false
+      },
+      error: postWebExploreGuardError
+    };
+
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      details: result,
+      isError: true as const
     };
   }
 
@@ -53,7 +96,7 @@ export default function extension(pi: ExtensionAPI) {
     }),
     async execute(_toolCallId, params) {
       if (webExploreUsedInCurrentFlow) {
-        return guardedLowLevelResponse();
+        return guardSearchResponse();
       }
 
       const result = await webSearch({ query: params.query });
@@ -75,7 +118,7 @@ export default function extension(pi: ExtensionAPI) {
     }),
     async execute(_toolCallId, params) {
       if (webExploreUsedInCurrentFlow) {
-        return guardedLowLevelResponse();
+        return guardFetchResponse(params.url);
       }
 
       const result = await webFetch({ url: params.url });
@@ -97,7 +140,7 @@ export default function extension(pi: ExtensionAPI) {
     }),
     async execute(_toolCallId, params) {
       if (webExploreUsedInCurrentFlow) {
-        return guardedLowLevelResponse();
+        return guardHeadlessResponse(params.url);
       }
 
       const result = await webFetchHeadless({ url: params.url });

--- a/src/search/duckduckgo.ts
+++ b/src/search/duckduckgo.ts
@@ -1,6 +1,12 @@
 import * as cheerio from 'cheerio';
 import type { SearchResult } from '../types.js';
 
+export type ParsedDuckDuckGoResults = {
+  results: SearchResult[];
+  noResults: boolean;
+  hasResultContainers: boolean;
+};
+
 function normalizeDuckDuckGoUrl(rawUrl: string): string {
   try {
     const absolute = rawUrl.startsWith('//') ? `https:${rawUrl}` : rawUrl;
@@ -35,10 +41,11 @@ export async function fetchDuckDuckGoHtml(query: string): Promise<string> {
   return response.text();
 }
 
-export function parseDuckDuckGoResults(html: string): SearchResult[] {
+export function parseDuckDuckGoResults(html: string): ParsedDuckDuckGoResults {
   const $ = cheerio.load(html);
+  const resultContainers = $('.result');
 
-  return $('.result')
+  const results = resultContainers
     .map((_, element) => {
       const title = $(element).find('.result__a').first().text().trim();
       const url = normalizeDuckDuckGoUrl(
@@ -50,4 +57,16 @@ export function parseDuckDuckGoResults(html: string): SearchResult[] {
     })
     .get()
     .filter((value): value is SearchResult => value !== null);
+
+  const text = $.text().toLowerCase();
+  const noResults =
+    text.includes('no results found') ||
+    text.includes('no more results') ||
+    text.includes('did not match any documents');
+
+  return {
+    results,
+    noResults,
+    hasResultContainers: resultContainers.length > 0
+  };
 }

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -35,20 +35,46 @@ export function createWebSearchTool({
 
     try {
       const html = await searchHtml(normalizedQuery);
-      const result: WebSearchResponse = {
-        status: 'ok',
-        results: parseDuckDuckGoResults(html),
-        metadata: { backend: 'duckduckgo', cacheHit: false }
+      const parsed = parseDuckDuckGoResults(html);
+
+      if (parsed.results.length > 0) {
+        const result: WebSearchResponse = {
+          status: 'ok',
+          results: parsed.results,
+          metadata: { backend: 'duckduckgo', cacheHit: false }
+        };
+        cache.set(cacheKey, result);
+        return result;
+      }
+
+      if (parsed.noResults) {
+        return {
+          status: 'error',
+          results: [],
+          metadata: { backend: 'duckduckgo', cacheHit: false },
+          error: {
+            code: 'NO_RESULTS',
+            message: 'DuckDuckGo returned no usable results for this query.'
+          }
+        };
+      }
+
+      return {
+        status: 'error',
+        results: [],
+        metadata: { backend: 'duckduckgo', cacheHit: false },
+        error: {
+          code: 'PARSE_FAILED',
+          message: 'DuckDuckGo returned a page, but it did not match the expected results format.'
+        }
       };
-      cache.set(cacheKey, result);
-      return result;
     } catch (error) {
       return {
         status: 'error',
         results: [],
         metadata: { backend: 'duckduckgo', cacheHit: false },
         error: {
-          code: 'SEARCH_FAILED',
+          code: 'FETCH_FAILED',
           message: error instanceof Error ? error.message : 'Unknown search failure.'
         }
       };

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -2,6 +2,31 @@ import { createCacheKey, createTtlCache } from '../cache/ttl-cache.js';
 import { fetchDuckDuckGoHtml, parseDuckDuckGoResults } from '../search/duckduckgo.js';
 import type { WebSearchResponse } from '../types.js';
 
+function classifySearchFailure(error: unknown) {
+  const rawMessage = error instanceof Error ? error.message : 'Unknown search failure.';
+  const normalized = rawMessage.toLowerCase();
+
+  if (
+    normalized.includes('blocked') ||
+    normalized.includes('rate limit') ||
+    normalized.includes('rate-limit') ||
+    normalized.includes('403') ||
+    normalized.includes('429') ||
+    normalized.includes('captcha') ||
+    normalized.includes('challenge')
+  ) {
+    return {
+      code: 'BLOCKED',
+      message: 'DuckDuckGo search appears to be blocked or rate limited.'
+    };
+  }
+
+  return {
+    code: 'FETCH_FAILED',
+    message: `DuckDuckGo search request failed: ${rawMessage}`
+  };
+}
+
 export function createWebSearchTool({
   searchHtml = fetchDuckDuckGoHtml,
   cache = createTtlCache<WebSearchResponse>({ ttlMs: 30_000 })
@@ -73,10 +98,7 @@ export function createWebSearchTool({
         status: 'error',
         results: [],
         metadata: { backend: 'duckduckgo', cacheHit: false },
-        error: {
-          code: 'FETCH_FAILED',
-          message: error instanceof Error ? error.message : 'Unknown search failure.'
-        }
+        error: classifySearchFailure(error)
       };
     }
   };

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -27,6 +27,18 @@ function classifySearchFailure(error: unknown) {
   };
 }
 
+function htmlLooksBlocked(html: string) {
+  const normalized = html.toLowerCase();
+
+  return (
+    normalized.includes('captcha') ||
+    normalized.includes('challenge') ||
+    normalized.includes('verify you are human') ||
+    normalized.includes('are you a robot') ||
+    normalized.includes('unusual traffic')
+  );
+}
+
 export function createWebSearchTool({
   searchHtml = fetchDuckDuckGoHtml,
   cache = createTtlCache<WebSearchResponse>({ ttlMs: 30_000 })
@@ -80,6 +92,18 @@ export function createWebSearchTool({
           error: {
             code: 'NO_RESULTS',
             message: 'DuckDuckGo returned no usable results for this query.'
+          }
+        };
+      }
+
+      if (htmlLooksBlocked(html)) {
+        return {
+          status: 'error',
+          results: [],
+          metadata: { backend: 'duckduckgo', cacheHit: false },
+          error: {
+            code: 'BLOCKED',
+            message: 'DuckDuckGo search appears to be blocked or rate limited.'
           }
         };
       }

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -119,4 +119,46 @@ describe('Pi extension entrypoint', () => {
     expect(result.content[0].text).toContain('Findings');
     expect(result.content[0].text).toContain('Sources');
   }, 15000);
+
+  it('blocks low-level web_search after a successful web_explore in the same tool flow', async () => {
+    const tools: any[] = [];
+    const pi = {
+      registerTool: (tool: any) => tools.push(tool),
+      on: vi.fn()
+    };
+
+    extension(pi as never);
+
+    const webExplore = tools.find((tool) => tool.name === 'web_explore');
+    const webSearch = tools.find((tool) => tool.name === 'web_search');
+
+    await webExplore.execute('tool-call-1', { query: 'example query' });
+    const result = await webSearch.execute('tool-call-2', { query: 'follow-up search' });
+
+    expect(result.isError).toBe(true);
+    expect(result.details).toMatchObject({
+      status: 'error',
+      error: {
+        code: 'POST_WEB_EXPLORE_GUARD',
+        message:
+          'web_explore already ran for this research task. Only use low-level web tools if there is a specific unresolved gap.'
+      }
+    });
+  }, 15000);
+
+  it('still allows low-level tools before web_explore runs', async () => {
+    const tools: any[] = [];
+    const pi = {
+      registerTool: (tool: any) => tools.push(tool),
+      on: vi.fn()
+    };
+
+    extension(pi as never);
+
+    const webSearch = tools.find((tool) => tool.name === 'web_search');
+    const result = await webSearch.execute('tool-call-1', { query: 'plain search' });
+
+    expect(result.details.status).not.toBe('error');
+    expect(result.details.error?.code).not.toBe('POST_WEB_EXPLORE_GUARD');
+  }, 15000);
 });

--- a/tests/search/duckduckgo.test.ts
+++ b/tests/search/duckduckgo.test.ts
@@ -11,20 +11,24 @@ describe('DuckDuckGo search parsing', () => {
 
   it('parses normalized title, url, and snippet records', () => {
     const html = readFileSync('tests/fixtures/duckduckgo/basic-results.html', 'utf8');
-    const results = parseDuckDuckGoResults(html);
+    const parsed = parseDuckDuckGoResults(html);
 
-    expect(results).toEqual([
-      {
-        title: 'Example Article',
-        url: 'https://example.com/article',
-        snippet: 'First example snippet.'
-      },
-      {
-        title: 'Another Result',
-        url: 'https://example.org/post',
-        snippet: 'Second example snippet.'
-      }
-    ]);
+    expect(parsed).toEqual({
+      results: [
+        {
+          title: 'Example Article',
+          url: 'https://example.com/article',
+          snippet: 'First example snippet.'
+        },
+        {
+          title: 'Another Result',
+          url: 'https://example.org/post',
+          snippet: 'Second example snippet.'
+        }
+      ],
+      noResults: false,
+      hasResultContainers: true
+    });
   });
 
   it('decodes DuckDuckGo redirect urls into destination urls', () => {
@@ -35,15 +39,19 @@ describe('DuckDuckGo search parsing', () => {
       </div>
     `;
 
-    const results = parseDuckDuckGoResults(html);
+    const parsed = parseDuckDuckGoResults(html);
 
-    expect(results).toEqual([
-      {
-        title: 'pi.dev',
-        url: 'https://pi.dev/',
-        snippet: 'Pi docs'
-      }
-    ]);
+    expect(parsed).toEqual({
+      results: [
+        {
+          title: 'pi.dev',
+          url: 'https://pi.dev/',
+          snippet: 'Pi docs'
+        }
+      ],
+      noResults: false,
+      hasResultContainers: true
+    });
   });
 
   it('falls back to the original url when redirect decoding fails', () => {
@@ -54,14 +62,59 @@ describe('DuckDuckGo search parsing', () => {
       </div>
     `;
 
-    const results = parseDuckDuckGoResults(html);
+    const parsed = parseDuckDuckGoResults(html);
 
-    expect(results).toEqual([
-      {
-        title: 'broken',
-        url: '//duckduckgo.com/l/?uddg=%E0%A4%A&rut=abc',
-        snippet: 'Broken redirect'
-      }
-    ]);
+    expect(parsed).toEqual({
+      results: [
+        {
+          title: 'broken',
+          url: '//duckduckgo.com/l/?uddg=%E0%A4%A&rut=abc',
+          snippet: 'Broken redirect'
+        }
+      ],
+      noResults: false,
+      hasResultContainers: true
+    });
+  });
+
+  it('detects a no-results page separately from a parse failure', () => {
+    const html = `
+      <html>
+        <body>
+          <div class="results">
+            <div class="no-results">No results found for your search.</div>
+          </div>
+        </body>
+      </html>
+    `;
+
+    const parsed = parseDuckDuckGoResults(html);
+
+    expect(parsed).toEqual({
+      results: [],
+      noResults: true,
+      hasResultContainers: false
+    });
+  });
+
+  it('reports when the page does not match the expected results format', () => {
+    const html = `
+      <html>
+        <body>
+          <main>
+            <h1>Unexpected page</h1>
+            <p>Nothing here looks like a DuckDuckGo results page.</p>
+          </main>
+        </body>
+      </html>
+    `;
+
+    const parsed = parseDuckDuckGoResults(html);
+
+    expect(parsed).toEqual({
+      results: [],
+      noResults: false,
+      hasResultContainers: false
+    });
   });
 });

--- a/tests/tools/web-search.test.ts
+++ b/tests/tools/web-search.test.ts
@@ -89,4 +89,32 @@ describe('web_search tool', () => {
       }
     });
   });
+
+  it('returns BLOCKED when the backend clearly looks blocked', async () => {
+    const search = createWebSearchTool({
+      searchHtml: vi.fn().mockRejectedValue(new Error('DuckDuckGo blocked the request with 403'))
+    });
+
+    await expect(search({ query: 'blocked query' })).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        code: 'BLOCKED',
+        message: 'DuckDuckGo search appears to be blocked or rate limited.'
+      }
+    });
+  });
+
+  it('returns FETCH_FAILED for generic backend failures', async () => {
+    const search = createWebSearchTool({
+      searchHtml: vi.fn().mockRejectedValue(new Error('socket hang up'))
+    });
+
+    await expect(search({ query: 'network issue' })).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        code: 'FETCH_FAILED',
+        message: 'DuckDuckGo search request failed: socket hang up'
+      }
+    });
+  });
 });

--- a/tests/tools/web-search.test.ts
+++ b/tests/tools/web-search.test.ts
@@ -45,4 +45,48 @@ describe('web_search tool', () => {
       error: { code: 'INVALID_QUERY' }
     });
   });
+
+  it('returns NO_RESULTS when the backend page is valid but contains no usable results', async () => {
+    const search = createWebSearchTool({
+      searchHtml: vi.fn().mockResolvedValue(`
+        <html>
+          <body>
+            <div class="results">
+              <div class="no-results">No results found for your search.</div>
+            </div>
+          </body>
+        </html>
+      `)
+    });
+
+    await expect(search({ query: 'missing thing' })).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        code: 'NO_RESULTS',
+        message: 'DuckDuckGo returned no usable results for this query.'
+      }
+    });
+  });
+
+  it('returns PARSE_FAILED when the backend page cannot be understood as search results', async () => {
+    const search = createWebSearchTool({
+      searchHtml: vi.fn().mockResolvedValue(`
+        <html>
+          <body>
+            <main>
+              <h1>Unexpected page</h1>
+            </main>
+          </body>
+        </html>
+      `)
+    });
+
+    await expect(search({ query: 'odd page' })).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        code: 'PARSE_FAILED',
+        message: 'DuckDuckGo returned a page, but it did not match the expected results format.'
+      }
+    });
+  });
 });

--- a/tests/tools/web-search.test.ts
+++ b/tests/tools/web-search.test.ts
@@ -104,6 +104,29 @@ describe('web_search tool', () => {
     });
   });
 
+  it('returns BLOCKED when a 200 response is really a challenge page', async () => {
+    const search = createWebSearchTool({
+      searchHtml: vi.fn().mockResolvedValue(`
+        <html>
+          <body>
+            <main>
+              <h1>Are you a robot?</h1>
+              <p>Please verify you are human to continue.</p>
+            </main>
+          </body>
+        </html>
+      `)
+    });
+
+    await expect(search({ query: 'challenge page' })).resolves.toMatchObject({
+      status: 'error',
+      error: {
+        code: 'BLOCKED',
+        message: 'DuckDuckGo search appears to be blocked or rate limited.'
+      }
+    });
+  });
+
   it('returns FETCH_FAILED for generic backend failures', async () => {
     const search = createWebSearchTool({
       searchHtml: vi.fn().mockRejectedValue(new Error('socket hang up'))


### PR DESCRIPTION
Bunch of cleanup around the web tools.

Search failures are a lot more specific now instead of collapsing into vague generic errors, and the post-web_explore follow-up churn is finally under control without leaking reminder text into normal sessions.

Also expanded the live eval so it covers the deterministic search failure cases and reports guarded follow-up attempts separately. Latest run came back clean for both issue tracks.

closes #4
closes #10