### PR TITLE
release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ The format is intentionally simple and release-oriented.
 ### Breaking
 - None.
 
+## [0.2.2] - 2026-04-21
+### Added
+- Expanded the live web eval so it covers deterministic search failure cases and reports when follow-up web calls were blocked after `web_explore`.
+
+### Changed
+- Tightened post-`web_explore` discipline by blocking same-flow low-level web tool churn instead of relying on prompt wording alone.
+
+### Fixed
+- Split `web_search` failures into more useful states like no results, parse failures, blocked pages, and fetch failures.
+- Catch DuckDuckGo challenge pages that still return HTTP 200 so blocked searches stop looking like vague parser bugs.
+- Stopped the model from spiraling into extra `web_search` / `web_fetch` calls after a successful `web_explore` in the live-eval cases.
+
+### Breaking
+- None.
+
 ## [0.2.1] - 2026-04-20
 ### Added
 - Nothing yet.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@demigodmode/pi-web-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@demigodmode/pi-web-agent",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demigodmode/pi-web-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Pi package for reliable web access with explicit search, fetch, and headless boundaries.",
   "type": "module",
   "main": "./dist/extension.js",


### PR DESCRIPTION
Version bump for 0.2.2 and the changelog entries for the search failure work plus the post-web_explore guard.

Keeping this separate so the protected main flow stays clean and the tag lands on the merged main commit instead of some stray local commit.