### PR TITLE
fix npm trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,12 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
           cache: npm
+      - run: npm install -g npm@latest
+      - run: node -v
+      - run: npm -v
       - run: npm ci
       - run: npm install --no-save @rollup/rollup-linux-x64-gnu
       - run: npm run lint
       - run: npm test
       - run: npm run build
       - run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/tests/publish-workflow.test.ts
+++ b/tests/publish-workflow.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflowPath = path.join(process.cwd(), '.github', 'workflows', 'publish.yml');
+const workflow = readFileSync(workflowPath, 'utf8');
+
+describe('publish workflow', () => {
+  it('uses npm trusted publishing instead of an npm token', () => {
+    expect(workflow).toContain('id-token: write');
+    expect(workflow).not.toContain('NODE_AUTH_TOKEN');
+    expect(workflow).not.toContain('NPM_TOKEN');
+  });
+
+  it('upgrades npm before publishing so trusted publishing has a supported cli', () => {
+    expect(workflow).toContain('npm install -g npm@latest');
+    expect(workflow).toContain('npm -v');
+    expect(workflow).toContain('node -v');
+  });
+
+  it('still publishes the package with public access and provenance enabled', () => {
+    expect(workflow).toContain('npm publish --access public --provenance');
+  });
+});


### PR DESCRIPTION
This switches the publish job back to actual trusted publishing instead of the token path that kept failing.

Removed NODE_AUTH_TOKEN from the publish step, added an npm upgrade in the workflow, and added a small test so we keep checking that publish.yml stays on the OIDC path. Also prints node/npm versions in the job now so future failures are less opaque.