### PR TITLE
compact web tool output + real settings UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ The format is intentionally simple and release-oriented.
 ## Unreleased
 
 ### Added
-- Nothing yet.
+- Added compact, preview, and verbose presentation modes for web tool output.
+- Added a user-facing `/web-agent` settings UI plus helper commands for showing, resetting, and changing presentation config.
+- Added global and project-local presentation config files with project-overrides-global precedence.
+- Added docs for presentation settings, config paths, and command usage.
 
 ### Changed
-- Nothing yet.
+- Made compact output the default presentation mode for all web tools.
+- Made bare `/web-agent` open the settings UI directly.
 
 ### Fixed
-- Nothing yet.
+- Fixed settings scope switching so global and project drafts do not leak into each other.
+- Fixed config persistence so inherited values are not unnecessarily written into lower-precedence config files.
+- Fixed command notifications to use supported Pi UI notify levels.
 
 ### Breaking
 - None.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,62 @@ Build the docs:
 npm run docs:build
 ```
 
+## Presentation modes
+
+`pi-web-agent` renders web tool output in one visible mode at a time:
+
+- `compact` — short summary, default everywhere
+- `preview` — slightly richer bounded view
+- `verbose` — fuller bounded view
+
+## Settings
+
+Primary UI:
+
+```text
+/web-agent settings
+```
+
+Helper commands:
+
+```text
+/web-agent show
+/web-agent reset project
+/web-agent reset global
+/web-agent mode preview
+/web-agent mode web_search verbose
+/web-agent mode web_search inherit
+```
+
+Config files:
+
+```text
+Global:  ~/.pi/agent/extensions/pi-web-agent/config.json
+Project: .pi/extensions/pi-web-agent/config.json
+```
+
+Precedence:
+
+- built-in defaults
+- global config
+- project config
+
+Project config overrides global config.
+
+Example:
+
+```json
+{
+  "presentation": {
+    "defaultMode": "compact",
+    "tools": {
+      "web_search": { "mode": "preview" },
+      "web_explore": { "mode": "verbose" }
+    }
+  }
+}
+```
+
 ## Local development
 
 ```bash

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
     nav: [
       { text: 'Getting started', link: '/getting-started' },
       { text: 'Tools', link: '/tools' },
+      { text: 'Presentation', link: '/presentation' },
       { text: 'Development', link: '/development' },
       { text: 'GitHub', link: 'https://github.com/demigodmode/pi-web-agent' }
     ],
@@ -19,6 +20,7 @@ export default defineConfig({
           { text: 'Home', link: '/' },
           { text: 'Getting started', link: '/getting-started' },
           { text: 'Install', link: '/install' },
+          { text: 'Presentation and settings', link: '/presentation' },
           { text: 'Setup modes', link: '/setup-modes' },
           { text: 'Tools', link: '/tools' },
           { text: 'Architecture', link: '/architecture' },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,20 @@ That should favor `web_fetch_headless` when browser rendering is actually the po
 
 That should favor `web_explore` for the broader research workflow.
 
+## Presentation defaults
+
+The package renders web tool output in `compact` mode by default.
+
+If you want to change that, open the settings UI with:
+
+```text
+/web-agent
+```
+
+That lets you change the default mode and per-tool overrides without editing code.
+
+If you want the full details, see [Presentation and settings](/presentation).
+
 ## One thing to keep in mind
 
 If the package says a page was too weak to trust over HTTP, that is not it being stubborn. That is the whole point of the contract.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,10 +29,12 @@ Right now it gives you:
 - plain HTTP fetch that can say "this isn't reliable enough"
 - explicit headless fetch when a browser is actually needed
 - a higher-level research tool that is meant to stop after a bounded pass instead of wandering forever
+- compact-by-default transcript output with user-facing presentation settings
 
 ## Start here
 
 - If you want to try it quickly, start with [Getting started](/getting-started).
 - If you want the install details, go to [Install](/install).
 - If you want to understand the tool behavior first, go to [Tools](/tools).
+- If you want to change transcript output and config, go to [Presentation and settings](/presentation).
 - If you want to work on the repo, go to [Development](/development).

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,6 +23,26 @@ This repo also includes a project-local Pi extension entrypoint at `.pi/extensio
 
 That path is for local development and reloads while you are working in this repo.
 
+## Config files after install
+
+The package stores presentation settings in real JSON files.
+
+Global config:
+
+```text
+~/.pi/agent/extensions/pi-web-agent/config.json
+```
+
+Project config:
+
+```text
+.pi/extensions/pi-web-agent/config.json
+```
+
+Project config overrides global config.
+
+If you change settings through `/web-agent`, those files are what get updated.
+
 ## Watch out for mixed setups
 
 If you have both the npm-installed package and the local repo-based extension in play, it gets easy to think you are testing one copy when Pi is actually loading the other.

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -1,0 +1,136 @@
+# Presentation and settings
+
+`pi-web-agent` keeps web tool output compact by default.
+
+That is deliberate. Search results, fetches, and research summaries can get noisy fast, especially when the package is doing exactly what you asked and returning a lot of useful detail. The goal here is to keep the transcript readable first, while still letting you ask for more when you want it.
+
+## The three presentation modes
+
+Every web tool result is shaped into one visible mode at a time:
+
+- `compact` — the shortest useful summary
+- `preview` — a little more context, still bounded
+- `verbose` — the fullest bounded view
+
+The important part is that these are not stacked on top of each other.
+
+If a tool result is shown in `preview`, you get the preview body instead of a compact summary plus extra text under it.
+
+## Default behavior
+
+Out of the box, all tools use `compact`:
+
+- `web_search`
+- `web_fetch`
+- `web_fetch_headless`
+- `web_explore`
+
+That keeps normal usage calm instead of turning every search or fetch into a transcript dump.
+
+## The fastest way to change it
+
+Open the settings UI:
+
+```text
+/web-agent
+```
+
+That is the shorthand. The explicit form is:
+
+```text
+/web-agent settings
+```
+
+These also work:
+
+```text
+/web-agent settings
+/web-agent show
+/web-agent reset project
+/web-agent reset global
+/web-agent mode preview
+/web-agent mode web_search verbose
+/web-agent mode web_search inherit
+```
+
+## What `/web-agent` does
+
+`/web-agent` and `/web-agent settings` both open the interactive settings UI.
+
+From there you can:
+
+- choose whether you are editing global or project settings
+- change the default mode
+- change per-tool overrides
+- save, reset the current scope, or cancel
+
+Keyboard shortcuts in the settings UI:
+
+- `Ctrl+S` save
+- `Ctrl+R` reset current scope
+- `Esc` cancel
+
+## Config files
+
+Settings are stored in real JSON files.
+
+Global config:
+
+```text
+~/.pi/agent/extensions/pi-web-agent/config.json
+```
+
+Project config:
+
+```text
+.pi/extensions/pi-web-agent/config.json
+```
+
+## Precedence
+
+Effective behavior is resolved in this order:
+
+1. built-in defaults
+2. global config
+3. project config
+
+Project config overrides global config.
+
+That means you can keep a personal default and then override it inside one repo when you want different transcript behavior there.
+
+## How inheritance works
+
+Per-tool overrides inherit from the current default mode unless you set them explicitly.
+
+So if your default mode is `preview` and only `web_explore` is set to `verbose`, then:
+
+- `web_search` uses `preview`
+- `web_fetch` uses `preview`
+- `web_fetch_headless` uses `preview`
+- `web_explore` uses `verbose`
+
+When you switch a tool back to `inherit`, the package removes that override instead of writing extra noise into the config file.
+
+## Example config
+
+```json
+{
+  "presentation": {
+    "defaultMode": "compact",
+    "tools": {
+      "web_search": { "mode": "preview" },
+      "web_explore": { "mode": "verbose" }
+    }
+  }
+}
+```
+
+## When to use each mode
+
+A good practical rule:
+
+- use `compact` if you mostly want clean transcripts
+- use `preview` if you want a little more inline context for discovery and fetches
+- use `verbose` if you are actively inspecting tool output and do not mind a larger transcript
+
+For most people, `compact` as the default plus a couple of per-tool overrides is probably the sweet spot.

--- a/docs/setup-modes.md
+++ b/docs/setup-modes.md
@@ -10,6 +10,8 @@ The simplest path is just installing the package in Pi and using the tools as th
 
 If all you want is the current package behavior, this is the setup that matters.
 
+If you want to tune how tool output shows up in the transcript, see [Presentation and settings](/presentation).
+
 ## Hosted-backed setups
 
 Some of the open issues point toward hosted search providers.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -49,6 +49,14 @@ What it should not do is turn into endless low-level tool churn after a decent a
 
 That tighter behavior is intentional.
 
+## Presentation and transcript output
+
+These tools now render in a compact transcript-friendly form by default.
+
+That means using a tool does not automatically dump its fullest possible body inline. If you want richer output, change the package settings instead of expecting the transcript to always show the maximum amount of detail.
+
+See [Presentation and settings](/presentation) for the config UI, JSON paths, and mode behavior.
+
 ## Which one should you reach for?
 
 A quick rule of thumb:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,6 +18,23 @@ That can happen when:
 
 Again, this is exactly where a clean `needs_headless` result is more useful than fake certainty.
 
+## `/web-agent` did something unexpected
+
+`/web-agent` opens the settings UI.
+
+If you just want to inspect the currently effective config instead, use:
+
+```text
+/web-agent show
+```
+
+If the current behavior does not match what you expected, check both config scopes:
+
+- global: `~/.pi/agent/extensions/pi-web-agent/config.json`
+- project: `.pi/extensions/pi-web-agent/config.json`
+
+Project config overrides global config.
+
 ## Pi seems to be loading the wrong copy
 
 If you use both the published package and the local repo-based extension, double-check which one Pi actually loaded.

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -1,8 +1,13 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import {
+  getSettingsListTheme,
+  type ExtensionAPI
+} from '@mariozechner/pi-coding-agent';
+import { Container, SettingsList, Text, type SettingItem } from '@mariozechner/pi-tui';
 import {
   loadPresentationConfigLayers,
   resetPresentationConfigScope,
-  savePresentationConfigScope
+  savePresentationConfigScope,
+  type LoadedPresentationConfig
 } from '../presentation/config-store.js';
 import type {
   PresentationConfig,
@@ -16,23 +21,154 @@ type CommandDeps = {
   reset?: (scope: PresentationScope) => Promise<void>;
 };
 
+type SettingsUiResult =
+  | { action: 'cancel' }
+  | { action: 'reset'; scope: PresentationScope }
+  | { action: 'save'; scope: PresentationScope; config: PresentationConfig };
+
+const PRESENTATION_TOOL_NAMES: PresentationToolName[] = [
+  'web_search',
+  'web_fetch',
+  'web_fetch_headless',
+  'web_explore'
+];
+
 function parseScopeToken(token: string | undefined): PresentationScope | undefined {
   return token === 'global' || token === 'project' ? token : undefined;
+}
+
+function clonePresentationConfig(config: PresentationConfig): PresentationConfig {
+  return {
+    defaultMode: config.defaultMode,
+    tools: { ...config.tools }
+  };
 }
 
 function formatConfigSummary(config: PresentationConfig) {
   const lines = [`defaultMode: ${config.defaultMode}`];
 
-  for (const toolName of [
-    'web_search',
-    'web_fetch',
-    'web_fetch_headless',
-    'web_explore'
-  ] as PresentationToolName[]) {
+  for (const toolName of PRESENTATION_TOOL_NAMES) {
     lines.push(`${toolName}: ${config.tools[toolName]?.mode ?? 'inherit'}`);
   }
 
   return lines.join('\n');
+}
+
+function buildSettingsItems(scope: PresentationScope, config: PresentationConfig): SettingItem[] {
+  return [
+    {
+      id: 'scope',
+      label: 'Write scope',
+      currentValue: scope,
+      values: ['project', 'global']
+    },
+    {
+      id: 'defaultMode',
+      label: 'Default mode',
+      currentValue: config.defaultMode,
+      values: ['compact', 'preview', 'verbose']
+    },
+    ...PRESENTATION_TOOL_NAMES.map((toolName) => ({
+      id: `tool:${toolName}`,
+      label: toolName,
+      currentValue: config.tools[toolName]?.mode ?? 'inherit',
+      values: ['inherit', 'compact', 'preview', 'verbose']
+    }))
+  ];
+}
+
+function getScopeDraft(loaded: Awaited<LoadedPresentationConfig>, scope: PresentationScope) {
+  if (scope === 'global') {
+    return loaded.global.rawConfig
+      ? {
+          defaultMode: loaded.global.rawConfig.defaultMode ?? loaded.effectiveConfig.defaultMode,
+          tools: { ...loaded.global.rawConfig.tools }
+        }
+      : clonePresentationConfig(loaded.effectiveConfig);
+  }
+
+  return loaded.project.rawConfig
+    ? {
+        defaultMode: loaded.project.rawConfig.defaultMode ?? loaded.effectiveConfig.defaultMode,
+        tools: { ...loaded.project.rawConfig.tools }
+      }
+    : clonePresentationConfig(loaded.effectiveConfig);
+}
+
+async function openSettingsUi(
+  ctx: any,
+  initialScope: PresentationScope,
+  initialConfig: PresentationConfig
+): Promise<SettingsUiResult | undefined> {
+  return ctx.ui.custom((_tui: unknown, theme: any, _kb: unknown, done: (value: SettingsUiResult) => void) => {
+    let draftScope: PresentationScope = initialScope;
+    let draftConfig = clonePresentationConfig(initialConfig);
+    let settingsList: SettingsList;
+
+    const container = new Container();
+    container.addChild(new Text(theme.fg('accent', theme.bold('pi-web-agent settings')), 1, 1));
+
+    const rebuildSettingsList = () => {
+      if (settingsList) {
+        container.removeChild(settingsList);
+      }
+
+      settingsList = new SettingsList(
+        buildSettingsItems(draftScope, draftConfig),
+        Math.min(PRESENTATION_TOOL_NAMES.length + 6, 18),
+        getSettingsListTheme(),
+        (id, newValue) => {
+          if (id === 'scope' && (newValue === 'project' || newValue === 'global')) {
+            draftScope = newValue;
+            rebuildSettingsList();
+            container.invalidate();
+            return;
+          }
+
+          if (
+            id === 'defaultMode' &&
+            (newValue === 'compact' || newValue === 'preview' || newValue === 'verbose')
+          ) {
+            draftConfig = { ...draftConfig, defaultMode: newValue };
+            rebuildSettingsList();
+            container.invalidate();
+            return;
+          }
+
+          if (id.startsWith('tool:')) {
+            const toolName = id.slice('tool:'.length) as PresentationToolName;
+            const nextTools = { ...draftConfig.tools };
+
+            if (newValue === 'inherit') {
+              delete nextTools[toolName];
+            } else if (
+              newValue === 'compact' ||
+              newValue === 'preview' ||
+              newValue === 'verbose'
+            ) {
+              nextTools[toolName] = { mode: newValue };
+            }
+
+            draftConfig = { ...draftConfig, tools: nextTools };
+            rebuildSettingsList();
+            container.invalidate();
+          }
+        },
+        () => done({ action: 'save', scope: draftScope, config: draftConfig }),
+        { enableSearch: true }
+      );
+
+      container.addChild(settingsList);
+    };
+
+    rebuildSettingsList();
+
+    return {
+      render: (width: number) => container.render(width),
+      invalidate: () => container.invalidate(),
+      handleInput: (data: string) => settingsList.handleInput?.(data)
+    };
+  });
 }
 
 export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDeps = {}) {
@@ -71,11 +207,25 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
       }
 
       if (action === 'settings') {
-        ctx.ui.notify('settings UI not implemented yet in this task', 'info');
+        const loaded = await load();
+        const initialScope: PresentationScope = 'project';
+        const result = await openSettingsUi(ctx, initialScope, getScopeDraft(loaded, initialScope));
+
+        if (!result || result.action === 'cancel') {
+          return;
+        }
+
+        if (result.action === 'reset') {
+          await reset(result.scope);
+          ctx.ui.notify(`Reset ${result.scope} config`, 'success');
+          return;
+        }
+
+        await save(result.scope, result.config);
+        ctx.ui.notify(`Saved ${result.scope} config`, 'success');
         return;
       }
 
-      void save;
       ctx.ui.notify(
         'Use /web-agent, /web-agent show, /web-agent reset project, or /web-agent settings',
         'info'

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -1,10 +1,85 @@
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import {
+  loadPresentationConfigLayers,
+  resetPresentationConfigScope,
+  savePresentationConfigScope
+} from '../presentation/config-store.js';
+import type {
+  PresentationConfig,
+  PresentationScope,
+  PresentationToolName
+} from '../presentation/types.js';
 
-export function registerWebAgentConfigCommands(pi: ExtensionAPI) {
+type CommandDeps = {
+  load?: () => ReturnType<typeof loadPresentationConfigLayers>;
+  save?: (scope: PresentationScope, config: PresentationConfig) => Promise<void>;
+  reset?: (scope: PresentationScope) => Promise<void>;
+};
+
+function parseScopeToken(token: string | undefined): PresentationScope | undefined {
+  return token === 'global' || token === 'project' ? token : undefined;
+}
+
+function formatConfigSummary(config: PresentationConfig) {
+  const lines = [`defaultMode: ${config.defaultMode}`];
+
+  for (const toolName of [
+    'web_search',
+    'web_fetch',
+    'web_fetch_headless',
+    'web_explore'
+  ] as PresentationToolName[]) {
+    lines.push(`${toolName}: ${config.tools[toolName]?.mode ?? 'inherit'}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDeps = {}) {
+  const load = deps.load ?? (() => loadPresentationConfigLayers());
+  const save = deps.save ?? ((scope, config) => savePresentationConfigScope({}, scope, config));
+  const reset = deps.reset ?? ((scope) => resetPresentationConfigScope({}, scope));
+
   pi.registerCommand('web-agent', {
     description: 'Open settings or manage pi-web-agent presentation config',
-    handler: async (_args, ctx) => {
-      ctx.ui.notify('web-agent settings are not wired up yet', 'info');
+    handler: async (args, ctx) => {
+      const [action, maybeScope] = (args ?? '').trim().split(/\s+/).filter(Boolean);
+
+      if (!action || action === 'show') {
+        const loaded = await load();
+        ctx.ui.notify(
+          [
+            formatConfigSummary(loaded.effectiveConfig),
+            `global: ${loaded.global.path}${loaded.global.exists ? '' : ' (missing)'}`,
+            `project: ${loaded.project.path}${loaded.project.exists ? '' : ' (missing)'}`
+          ].join('\n'),
+          'info'
+        );
+        return;
+      }
+
+      if (action === 'reset') {
+        const scope = parseScopeToken(maybeScope) ?? 'project';
+        await reset(scope);
+        ctx.ui.notify(`Reset ${scope} config`, 'success');
+        return;
+      }
+
+      if (action === 'mode') {
+        ctx.ui.notify('mode command not implemented yet in this task', 'info');
+        return;
+      }
+
+      if (action === 'settings') {
+        ctx.ui.notify('settings UI not implemented yet in this task', 'info');
+        return;
+      }
+
+      void save;
+      ctx.ui.notify(
+        'Use /web-agent, /web-agent show, /web-agent reset project, or /web-agent settings',
+        'info'
+      );
     }
   });
 }

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -1,0 +1,10 @@
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+export function registerWebAgentConfigCommands(pi: ExtensionAPI) {
+  pi.registerCommand('web-agent', {
+    description: 'Open settings or manage pi-web-agent presentation config',
+    handler: async (_args, ctx) => {
+      ctx.ui.notify('web-agent settings are not wired up yet', 'info');
+    }
+  });
+}

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -314,7 +314,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
     handler: async (args, ctx) => {
       const [action, maybeScope] = (args ?? '').trim().split(/\s+/).filter(Boolean);
 
-      if (!action || action === 'show') {
+      if (action === 'show') {
         const loaded = await load();
         ctx.ui.notify(
           [
@@ -371,7 +371,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
         return;
       }
 
-      if (action === 'settings') {
+      if (!action || action === 'settings') {
         const loaded = await load();
         const initialScope: PresentationScope = 'project';
         const result = await openSettingsUi(ctx, loaded, initialScope);

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -205,7 +205,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
       if (action === 'reset') {
         const scope = parseScopeToken(maybeScope) ?? 'project';
         await reset(scope);
-        ctx.ui.notify(`Reset ${scope} config`, 'success');
+        ctx.ui.notify(`Reset ${scope} config`, 'info');
         return;
       }
 
@@ -217,7 +217,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
 
         if (first && isModeOrInherit(first) && first !== 'inherit') {
           await save(scope, { ...baseConfig, defaultMode: first });
-          ctx.ui.notify(`Saved project default mode = ${first}`, 'success');
+          ctx.ui.notify(`Saved project default mode = ${first}`, 'info');
           return;
         }
 
@@ -231,7 +231,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
           }
 
           await save(scope, { ...baseConfig, tools: nextTools });
-          ctx.ui.notify(`Saved project ${first} = ${second}`, 'success');
+          ctx.ui.notify(`Saved project ${first} = ${second}`, 'info');
           return;
         }
 
@@ -253,12 +253,12 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
 
         if (result.action === 'reset') {
           await reset(result.scope);
-          ctx.ui.notify(`Reset ${result.scope} config`, 'success');
+          ctx.ui.notify(`Reset ${result.scope} config`, 'info');
           return;
         }
 
         await save(result.scope, result.config);
-        ctx.ui.notify(`Saved ${result.scope} config`, 'success');
+        ctx.ui.notify(`Saved ${result.scope} config`, 'info');
         return;
       }
 

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -77,6 +77,14 @@ function buildSettingsItems(scope: PresentationScope, config: PresentationConfig
   ];
 }
 
+function isToolName(value: string): value is PresentationToolName {
+  return PRESENTATION_TOOL_NAMES.includes(value as PresentationToolName);
+}
+
+function isModeOrInherit(value: string): value is 'inherit' | 'compact' | 'preview' | 'verbose' {
+  return ['inherit', 'compact', 'preview', 'verbose'].includes(value);
+}
+
 function getScopeDraft(loaded: Awaited<LoadedPresentationConfig>, scope: PresentationScope) {
   if (scope === 'global') {
     return loaded.global.rawConfig
@@ -202,7 +210,35 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
       }
 
       if (action === 'mode') {
-        ctx.ui.notify('mode command not implemented yet in this task', 'info');
+        const [, first, second] = (args ?? '').trim().split(/\s+/).filter(Boolean);
+        const loaded = await load();
+        const scope: PresentationScope = 'project';
+        const baseConfig = getScopeDraft(loaded, scope);
+
+        if (first && isModeOrInherit(first) && first !== 'inherit') {
+          await save(scope, { ...baseConfig, defaultMode: first });
+          ctx.ui.notify(`Saved project default mode = ${first}`, 'success');
+          return;
+        }
+
+        if (first && second && isToolName(first) && isModeOrInherit(second)) {
+          const nextTools = { ...baseConfig.tools };
+
+          if (second === 'inherit') {
+            delete nextTools[first];
+          } else {
+            nextTools[first] = { mode: second };
+          }
+
+          await save(scope, { ...baseConfig, tools: nextTools });
+          ctx.ui.notify(`Saved project ${first} = ${second}`, 'success');
+          return;
+        }
+
+        ctx.ui.notify(
+          'Usage: /web-agent mode <compact|preview|verbose> or /web-agent mode <tool> <inherit|compact|preview|verbose>',
+          'info'
+        );
         return;
       }
 

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -4,6 +4,11 @@ import {
 } from '@mariozechner/pi-coding-agent';
 import { Container, SettingsList, Text, type SettingItem } from '@mariozechner/pi-tui';
 import {
+  DEFAULT_PRESENTATION_CONFIG,
+  mergePresentationConfigLayers,
+  resolvePresentationMode
+} from '../presentation/config.js';
+import {
   loadPresentationConfigLayers,
   resetPresentationConfigScope,
   savePresentationConfigScope,
@@ -11,13 +16,14 @@ import {
 } from '../presentation/config-store.js';
 import type {
   PresentationConfig,
+  PresentationConfigOverride,
   PresentationScope,
   PresentationToolName
 } from '../presentation/types.js';
 
 type CommandDeps = {
   load?: () => ReturnType<typeof loadPresentationConfigLayers>;
-  save?: (scope: PresentationScope, config: PresentationConfig) => Promise<void>;
+  save?: (scope: PresentationScope, config: PresentationConfigOverride) => Promise<void>;
   reset?: (scope: PresentationScope) => Promise<void>;
 };
 
@@ -25,6 +31,12 @@ type SettingsUiResult =
   | { action: 'cancel' }
   | { action: 'reset'; scope: PresentationScope }
   | { action: 'save'; scope: PresentationScope; config: PresentationConfig };
+
+export type SettingsDraftState = {
+  scope: PresentationScope;
+  drafts: Record<PresentationScope, PresentationConfig>;
+  config: PresentationConfig;
+};
 
 const PRESENTATION_TOOL_NAMES: PresentationToolName[] = [
   'web_search',
@@ -85,36 +97,162 @@ function isModeOrInherit(value: string): value is 'inherit' | 'compact' | 'previ
   return ['inherit', 'compact', 'preview', 'verbose'].includes(value);
 }
 
-function getScopeDraft(loaded: Awaited<LoadedPresentationConfig>, scope: PresentationScope) {
+export function getInheritedConfigForScope(
+  loaded: Awaited<LoadedPresentationConfig>,
+  scope: PresentationScope
+): PresentationConfig {
   if (scope === 'global') {
-    return loaded.global.rawConfig
-      ? {
-          defaultMode: loaded.global.rawConfig.defaultMode ?? loaded.effectiveConfig.defaultMode,
-          tools: { ...loaded.global.rawConfig.tools }
-        }
-      : clonePresentationConfig(loaded.effectiveConfig);
+    return DEFAULT_PRESENTATION_CONFIG;
   }
 
-  return loaded.project.rawConfig
-    ? {
-        defaultMode: loaded.project.rawConfig.defaultMode ?? loaded.effectiveConfig.defaultMode,
-        tools: { ...loaded.project.rawConfig.tools }
+  return mergePresentationConfigLayers(DEFAULT_PRESENTATION_CONFIG, loaded.global.rawConfig);
+}
+
+export function getScopeDisplayConfig(
+  loaded: Awaited<LoadedPresentationConfig>,
+  scope: PresentationScope
+): PresentationConfig {
+  if (scope === 'global') {
+    return mergePresentationConfigLayers(DEFAULT_PRESENTATION_CONFIG, loaded.global.rawConfig);
+  }
+
+  return mergePresentationConfigLayers(
+    DEFAULT_PRESENTATION_CONFIG,
+    loaded.global.rawConfig,
+    loaded.project.rawConfig
+  );
+}
+
+export function createSettingsDraftState(
+  loaded: Awaited<LoadedPresentationConfig>,
+  initialScope: PresentationScope
+): SettingsDraftState {
+  const drafts = {
+    global: getScopeDisplayConfig(loaded, 'global'),
+    project: getScopeDisplayConfig(loaded, 'project')
+  };
+
+  return {
+    scope: initialScope,
+    drafts,
+    config: clonePresentationConfig(drafts[initialScope])
+  };
+}
+
+export function applySettingsValue(
+  state: SettingsDraftState,
+  id: string,
+  newValue: string
+): SettingsDraftState {
+  const nextDrafts = {
+    global: clonePresentationConfig(state.drafts.global),
+    project: clonePresentationConfig(state.drafts.project)
+  };
+
+  let nextScope = state.scope;
+
+  if (id === 'scope' && (newValue === 'project' || newValue === 'global')) {
+    nextScope = newValue;
+    return {
+      scope: nextScope,
+      drafts: nextDrafts,
+      config: clonePresentationConfig(nextDrafts[nextScope])
+    };
+  }
+
+  const currentDraft = clonePresentationConfig(nextDrafts[nextScope]);
+
+  if (id === 'defaultMode' && (newValue === 'compact' || newValue === 'preview' || newValue === 'verbose')) {
+    currentDraft.defaultMode = newValue;
+  }
+
+  if (id.startsWith('tool:')) {
+    const toolName = id.slice('tool:'.length) as PresentationToolName;
+    const nextTools = { ...currentDraft.tools };
+
+    if (newValue === 'inherit') {
+      delete nextTools[toolName];
+    } else if (
+      newValue === 'compact' ||
+      newValue === 'preview' ||
+      newValue === 'verbose'
+    ) {
+      nextTools[toolName] = { mode: newValue };
+    }
+
+    currentDraft.tools = nextTools;
+  }
+
+  nextDrafts[nextScope] = currentDraft;
+
+  return {
+    scope: nextScope,
+    drafts: nextDrafts,
+    config: clonePresentationConfig(nextDrafts[nextScope])
+  };
+}
+
+export function collapsePresentationConfigToOverride(
+  config: PresentationConfig,
+  inheritedConfig: PresentationConfig
+): PresentationConfigOverride {
+  const tools = Object.fromEntries(
+    PRESENTATION_TOOL_NAMES.flatMap((toolName) => {
+      const configuredMode = config.tools[toolName]?.mode;
+      if (!configuredMode) {
+        return [];
       }
-    : clonePresentationConfig(loaded.effectiveConfig);
+
+      const inheritedMode = resolvePresentationMode(toolName, inheritedConfig);
+      if (configuredMode === inheritedMode) {
+        return [];
+      }
+
+      return [[toolName, { mode: configuredMode }]];
+    })
+  ) as PresentationConfigOverride['tools'];
+
+  return {
+    defaultMode:
+      config.defaultMode === inheritedConfig.defaultMode ? undefined : config.defaultMode,
+    tools
+  };
+}
+
+export function handleSettingsShortcut(data: string): { action: 'cancel' | 'reset' | 'save' } | undefined {
+  if (data === '\u001b') {
+    return { action: 'cancel' };
+  }
+
+  if (data === '\u0012') {
+    return { action: 'reset' };
+  }
+
+  if (data === '\u0013') {
+    return { action: 'save' };
+  }
+
+  return undefined;
 }
 
 async function openSettingsUi(
   ctx: any,
-  initialScope: PresentationScope,
-  initialConfig: PresentationConfig
+  loaded: Awaited<LoadedPresentationConfig>,
+  initialScope: PresentationScope
 ): Promise<SettingsUiResult | undefined> {
   return ctx.ui.custom((_tui: unknown, theme: any, _kb: unknown, done: (value: SettingsUiResult) => void) => {
-    let draftScope: PresentationScope = initialScope;
-    let draftConfig = clonePresentationConfig(initialConfig);
+    let state = createSettingsDraftState(loaded, initialScope);
     let settingsList: SettingsList;
 
     const container = new Container();
     container.addChild(new Text(theme.fg('accent', theme.bold('pi-web-agent settings')), 1, 1));
+    container.addChild(
+      new Text(
+        theme.fg('muted', 'Ctrl+S save · Ctrl+R reset scope · Esc cancel'),
+        1,
+        2
+      )
+    );
 
     const rebuildSettingsList = () => {
       if (settingsList) {
@@ -122,47 +260,15 @@ async function openSettingsUi(
       }
 
       settingsList = new SettingsList(
-        buildSettingsItems(draftScope, draftConfig),
-        Math.min(PRESENTATION_TOOL_NAMES.length + 6, 18),
+        buildSettingsItems(state.scope, state.config),
+        Math.min(PRESENTATION_TOOL_NAMES.length + 8, 18),
         getSettingsListTheme(),
         (id, newValue) => {
-          if (id === 'scope' && (newValue === 'project' || newValue === 'global')) {
-            draftScope = newValue;
-            rebuildSettingsList();
-            container.invalidate();
-            return;
-          }
-
-          if (
-            id === 'defaultMode' &&
-            (newValue === 'compact' || newValue === 'preview' || newValue === 'verbose')
-          ) {
-            draftConfig = { ...draftConfig, defaultMode: newValue };
-            rebuildSettingsList();
-            container.invalidate();
-            return;
-          }
-
-          if (id.startsWith('tool:')) {
-            const toolName = id.slice('tool:'.length) as PresentationToolName;
-            const nextTools = { ...draftConfig.tools };
-
-            if (newValue === 'inherit') {
-              delete nextTools[toolName];
-            } else if (
-              newValue === 'compact' ||
-              newValue === 'preview' ||
-              newValue === 'verbose'
-            ) {
-              nextTools[toolName] = { mode: newValue };
-            }
-
-            draftConfig = { ...draftConfig, tools: nextTools };
-            rebuildSettingsList();
-            container.invalidate();
-          }
+          state = applySettingsValue(state, id, newValue);
+          rebuildSettingsList();
+          container.invalidate();
         },
-        () => done({ action: 'save', scope: draftScope, config: draftConfig }),
+        () => done({ action: 'save', scope: state.scope, config: state.config }),
         { enableSearch: true }
       );
 
@@ -174,7 +280,26 @@ async function openSettingsUi(
     return {
       render: (width: number) => container.render(width),
       invalidate: () => container.invalidate(),
-      handleInput: (data: string) => settingsList.handleInput?.(data)
+      handleInput: (data: string) => {
+        const shortcut = handleSettingsShortcut(JSON.stringify(data).slice(1, -1));
+
+        if (shortcut?.action === 'cancel') {
+          done({ action: 'cancel' });
+          return;
+        }
+
+        if (shortcut?.action === 'reset') {
+          done({ action: 'reset', scope: state.scope });
+          return;
+        }
+
+        if (shortcut?.action === 'save') {
+          done({ action: 'save', scope: state.scope, config: state.config });
+          return;
+        }
+
+        settingsList.handleInput?.(data);
+      }
     };
   });
 }
@@ -213,10 +338,11 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
         const [, first, second] = (args ?? '').trim().split(/\s+/).filter(Boolean);
         const loaded = await load();
         const scope: PresentationScope = 'project';
-        const baseConfig = getScopeDraft(loaded, scope);
+        const baseConfig = getScopeDisplayConfig(loaded, scope);
+        const inheritedConfig = getInheritedConfigForScope(loaded, scope);
 
         if (first && isModeOrInherit(first) && first !== 'inherit') {
-          await save(scope, { ...baseConfig, defaultMode: first });
+          await save(scope, collapsePresentationConfigToOverride({ ...baseConfig, defaultMode: first }, inheritedConfig));
           ctx.ui.notify(`Saved project default mode = ${first}`, 'info');
           return;
         }
@@ -230,7 +356,10 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
             nextTools[first] = { mode: second };
           }
 
-          await save(scope, { ...baseConfig, tools: nextTools });
+          await save(
+            scope,
+            collapsePresentationConfigToOverride({ ...baseConfig, tools: nextTools }, inheritedConfig)
+          );
           ctx.ui.notify(`Saved project ${first} = ${second}`, 'info');
           return;
         }
@@ -245,7 +374,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
       if (action === 'settings') {
         const loaded = await load();
         const initialScope: PresentationScope = 'project';
-        const result = await openSettingsUi(ctx, initialScope, getScopeDraft(loaded, initialScope));
+        const result = await openSettingsUi(ctx, loaded, initialScope);
 
         if (!result || result.action === 'cancel') {
           return;
@@ -257,7 +386,13 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
           return;
         }
 
-        await save(result.scope, result.config);
+        await save(
+          result.scope,
+          collapsePresentationConfigToOverride(
+            result.config,
+            getInheritedConfigForScope(loaded, result.scope)
+          )
+        );
         ctx.ui.notify(`Saved ${result.scope} config`, 'info');
         return;
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,8 @@
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { Type } from '@sinclair/typebox';
+import { registerWebAgentConfigCommands } from './commands/web-agent-config.js';
 import { DEFAULT_PRESENTATION_CONFIG, resolvePresentationMode } from './presentation/config.js';
+import { loadPresentationConfigLayers } from './presentation/config-store.js';
 import { selectPresentationView } from './presentation/select-view.js';
 import type {
   PresentationConfig,
@@ -22,29 +24,36 @@ type ToolResultWithPresentation = {
   presentation?: PresentationEnvelope;
 };
 
-function getPresentationConfig(pi: ExtensionAPI): PresentationConfig {
-  const maybeConfig = (
+async function getEffectivePresentationConfig(pi: ExtensionAPI): Promise<PresentationConfig> {
+  const store = (
     pi as ExtensionAPI & {
-      getConfig?: () => {
-        presentation?: PresentationConfig;
+      __presentationConfigStore?: {
+        load?: typeof loadPresentationConfigLayers;
       };
     }
-  ).getConfig?.();
+  ).__presentationConfigStore;
 
-  return maybeConfig?.presentation ?? DEFAULT_PRESENTATION_CONFIG;
+  try {
+    const loaded = await (store?.load?.() ?? loadPresentationConfigLayers());
+    return loaded.effectiveConfig;
+  } catch {
+    return DEFAULT_PRESENTATION_CONFIG;
+  }
 }
 
-function renderToolText(
+async function renderToolText(
   pi: ExtensionAPI,
   toolName: PresentationToolName,
   details: ToolResultWithPresentation
-): string {
-  const config = getPresentationConfig(pi);
+): Promise<string> {
+  const config = await getEffectivePresentationConfig(pi);
   const mode = resolvePresentationMode(toolName, config);
   return selectPresentationView(details.presentation, mode) ?? JSON.stringify(details, null, 2);
 }
 
 export default function extension(pi: ExtensionAPI) {
+  registerWebAgentConfigCommands(pi);
+
   const webSearch = createWebSearchTool();
   const webFetch = createWebFetchTool();
   const webFetchHeadless = createWebFetchHeadlessTool();
@@ -56,7 +65,7 @@ export default function extension(pi: ExtensionAPI) {
       'web_explore already ran for this research task. Only use low-level web tools if there is a specific unresolved gap.'
   };
 
-  function guardSearchResponse() {
+  async function guardSearchResponse() {
     const result: WebSearchResponse = {
       status: 'error',
       results: [],
@@ -74,13 +83,13 @@ export default function extension(pi: ExtensionAPI) {
     };
 
     return {
-      content: [{ type: 'text' as const, text: renderToolText(pi, 'web_search', result) }],
+      content: [{ type: 'text' as const, text: await renderToolText(pi, 'web_search', result) }],
       details: result,
       isError: true as const
     };
   }
 
-  function guardFetchResponse(url: string) {
+  async function guardFetchResponse(url: string) {
     const result: WebFetchResponse = {
       status: 'error',
       url,
@@ -98,13 +107,13 @@ export default function extension(pi: ExtensionAPI) {
     };
 
     return {
-      content: [{ type: 'text' as const, text: renderToolText(pi, 'web_fetch', result) }],
+      content: [{ type: 'text' as const, text: await renderToolText(pi, 'web_fetch', result) }],
       details: result,
       isError: true as const
     };
   }
 
-  function guardHeadlessResponse(url: string) {
+  async function guardHeadlessResponse(url: string) {
     const result: WebFetchHeadlessResponse = {
       status: 'error',
       url,
@@ -123,7 +132,10 @@ export default function extension(pi: ExtensionAPI) {
 
     return {
       content: [
-        { type: 'text' as const, text: renderToolText(pi, 'web_fetch_headless', result) }
+        {
+          type: 'text' as const,
+          text: await renderToolText(pi, 'web_fetch_headless', result)
+        }
       ],
       details: result,
       isError: true as const
@@ -158,7 +170,7 @@ export default function extension(pi: ExtensionAPI) {
 
       const result = await webSearch({ query: params.query });
       return {
-        content: [{ type: 'text', text: renderToolText(pi, 'web_search', result) }],
+        content: [{ type: 'text', text: await renderToolText(pi, 'web_search', result) }],
         details: result,
         isError: result.status === 'error'
       };
@@ -180,7 +192,7 @@ export default function extension(pi: ExtensionAPI) {
 
       const result = await webFetch({ url: params.url });
       return {
-        content: [{ type: 'text', text: renderToolText(pi, 'web_fetch', result) }],
+        content: [{ type: 'text', text: await renderToolText(pi, 'web_fetch', result) }],
         details: result,
         isError: result.status === 'error'
       };
@@ -202,7 +214,7 @@ export default function extension(pi: ExtensionAPI) {
 
       const result = await webFetchHeadless({ url: params.url });
       return {
-        content: [{ type: 'text', text: renderToolText(pi, 'web_fetch_headless', result) }],
+        content: [{ type: 'text', text: await renderToolText(pi, 'web_fetch_headless', result) }],
         details: result,
         isError: result.status === 'error'
       };
@@ -227,7 +239,7 @@ export default function extension(pi: ExtensionAPI) {
         content: [
           {
             type: 'text',
-            text: renderToolText(pi, 'web_explore', result)
+            text: await renderToolText(pi, 'web_explore', result)
           }
         ],
         details: result,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,48 @@
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { Type } from '@sinclair/typebox';
+import { DEFAULT_PRESENTATION_CONFIG, resolvePresentationMode } from './presentation/config.js';
+import { selectPresentationView } from './presentation/select-view.js';
+import type {
+  PresentationConfig,
+  PresentationEnvelope,
+  PresentationToolName
+} from './presentation/types.js';
 import { createWebExploreTool } from './tools/web-explore.js';
 import { createWebFetchTool } from './tools/web-fetch.js';
 import { createWebFetchHeadlessTool } from './tools/web-fetch-headless.js';
 import { createWebSearchTool } from './tools/web-search.js';
-import type { WebFetchHeadlessResponse, WebFetchResponse, WebSearchResponse } from './types.js';
+import type {
+  WebExploreResponse,
+  WebFetchHeadlessResponse,
+  WebFetchResponse,
+  WebSearchResponse
+} from './types.js';
+
+type ToolResultWithPresentation = {
+  presentation?: PresentationEnvelope;
+};
+
+function getPresentationConfig(pi: ExtensionAPI): PresentationConfig {
+  const maybeConfig = (
+    pi as ExtensionAPI & {
+      getConfig?: () => {
+        presentation?: PresentationConfig;
+      };
+    }
+  ).getConfig?.();
+
+  return maybeConfig?.presentation ?? DEFAULT_PRESENTATION_CONFIG;
+}
+
+function renderToolText(
+  pi: ExtensionAPI,
+  toolName: PresentationToolName,
+  details: ToolResultWithPresentation
+): string {
+  const config = getPresentationConfig(pi);
+  const mode = resolvePresentationMode(toolName, config);
+  return selectPresentationView(details.presentation, mode) ?? JSON.stringify(details, null, 2);
+}
 
 export default function extension(pi: ExtensionAPI) {
   const webSearch = createWebSearchTool();
@@ -26,11 +64,17 @@ export default function extension(pi: ExtensionAPI) {
         backend: 'duckduckgo',
         cacheHit: false
       },
-      error: postWebExploreGuardError
+      error: postWebExploreGuardError,
+      presentation: {
+        mode: 'compact',
+        views: {
+          compact: `Search failed: ${postWebExploreGuardError.message}`
+        }
+      }
     };
 
     return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      content: [{ type: 'text' as const, text: renderToolText(pi, 'web_search', result) }],
       details: result,
       isError: true as const
     };
@@ -44,11 +88,17 @@ export default function extension(pi: ExtensionAPI) {
         method: 'http',
         cacheHit: false
       },
-      error: postWebExploreGuardError
+      error: postWebExploreGuardError,
+      presentation: {
+        mode: 'compact',
+        views: {
+          compact: `Fetch failed: ${postWebExploreGuardError.message}`
+        }
+      }
     };
 
     return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      content: [{ type: 'text' as const, text: renderToolText(pi, 'web_fetch', result) }],
       details: result,
       isError: true as const
     };
@@ -62,11 +112,19 @@ export default function extension(pi: ExtensionAPI) {
         method: 'headless',
         cacheHit: false
       },
-      error: postWebExploreGuardError
+      error: postWebExploreGuardError,
+      presentation: {
+        mode: 'compact',
+        views: {
+          compact: `Fetch failed: ${postWebExploreGuardError.message}`
+        }
+      }
     };
 
     return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      content: [
+        { type: 'text' as const, text: renderToolText(pi, 'web_fetch_headless', result) }
+      ],
       details: result,
       isError: true as const
     };
@@ -85,7 +143,6 @@ export default function extension(pi: ExtensionAPI) {
     };
   });
 
-
   pi.registerTool({
     name: 'web_search',
     label: 'Web Search',
@@ -101,7 +158,7 @@ export default function extension(pi: ExtensionAPI) {
 
       const result = await webSearch({ query: params.query });
       return {
-        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        content: [{ type: 'text', text: renderToolText(pi, 'web_search', result) }],
         details: result,
         isError: result.status === 'error'
       };
@@ -123,7 +180,7 @@ export default function extension(pi: ExtensionAPI) {
 
       const result = await webFetch({ url: params.url });
       return {
-        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        content: [{ type: 'text', text: renderToolText(pi, 'web_fetch', result) }],
         details: result,
         isError: result.status === 'error'
       };
@@ -145,7 +202,7 @@ export default function extension(pi: ExtensionAPI) {
 
       const result = await webFetchHeadless({ url: params.url });
       return {
-        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        content: [{ type: 'text', text: renderToolText(pi, 'web_fetch_headless', result) }],
         details: result,
         isError: result.status === 'error'
       };
@@ -161,7 +218,7 @@ export default function extension(pi: ExtensionAPI) {
       query: Type.String({ description: 'Web research question to explore.' })
     }),
     async execute(_toolCallId, params) {
-      const result = await webExplore({ query: params.query });
+      const result: WebExploreResponse = await webExplore({ query: params.query });
       if (result.status === 'ok') {
         webExploreUsedInCurrentFlow = true;
       }
@@ -170,7 +227,7 @@ export default function extension(pi: ExtensionAPI) {
         content: [
           {
             type: 'text',
-            text: result.status === 'ok' ? result.text : JSON.stringify(result, null, 2)
+            text: renderToolText(pi, 'web_explore', result)
           }
         ],
         details: result,

--- a/src/presentation/config-store.ts
+++ b/src/presentation/config-store.ts
@@ -1,0 +1,105 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  DEFAULT_PRESENTATION_CONFIG,
+  extractPresentationConfigOverride,
+  mergePresentationConfigLayers
+} from './config.js';
+import type {
+  PresentationConfig,
+  PresentationConfigFile,
+  PresentationConfigOverride,
+  PresentationScope
+} from './types.js';
+
+export type PresentationConfigStoreOptions = {
+  homeDir?: string;
+  projectDir?: string;
+};
+
+export type PresentationConfigLayer = {
+  path: string;
+  exists: boolean;
+  rawConfig?: PresentationConfigOverride;
+  error?: string;
+};
+
+export type LoadedPresentationConfig = {
+  global: PresentationConfigLayer;
+  project: PresentationConfigLayer;
+  effectiveConfig: PresentationConfig;
+};
+
+export function getPresentationConfigPaths(options: PresentationConfigStoreOptions = {}) {
+  const homeDir = options.homeDir ?? process.env.USERPROFILE ?? process.env.HOME ?? '';
+  const projectDir = options.projectDir ?? process.cwd();
+
+  return {
+    globalPath: path.join(homeDir, '.pi', 'agent', 'extensions', 'pi-web-agent', 'config.json'),
+    projectPath: path.join(projectDir, '.pi', 'extensions', 'pi-web-agent', 'config.json')
+  };
+}
+
+async function readPresentationConfigFile(filePath: string): Promise<PresentationConfigLayer> {
+  try {
+    const rawText = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(rawText) as PresentationConfigFile;
+
+    return {
+      path: filePath,
+      exists: true,
+      rawConfig: extractPresentationConfigOverride(parsed)
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT') {
+      return { path: filePath, exists: false };
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      path: filePath,
+      exists: true,
+      error: message
+    };
+  }
+}
+
+export async function loadPresentationConfigLayers(
+  options: PresentationConfigStoreOptions = {}
+): Promise<LoadedPresentationConfig> {
+  const { globalPath, projectPath } = getPresentationConfigPaths(options);
+  const global = await readPresentationConfigFile(globalPath);
+  const project = await readPresentationConfigFile(projectPath);
+
+  return {
+    global,
+    project,
+    effectiveConfig: mergePresentationConfigLayers(
+      DEFAULT_PRESENTATION_CONFIG,
+      global.rawConfig,
+      project.rawConfig
+    )
+  };
+}
+
+export async function savePresentationConfigScope(
+  options: PresentationConfigStoreOptions,
+  scope: PresentationScope,
+  config: PresentationConfig
+) {
+  const { globalPath, projectPath } = getPresentationConfigPaths(options);
+  const filePath = scope === 'global' ? globalPath : projectPath;
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify({ presentation: config }, null, 2) + '\n', 'utf8');
+}
+
+export async function resetPresentationConfigScope(
+  options: PresentationConfigStoreOptions,
+  scope: PresentationScope
+) {
+  const { globalPath, projectPath } = getPresentationConfigPaths(options);
+  const filePath = scope === 'global' ? globalPath : projectPath;
+
+  await rm(filePath, { force: true });
+}

--- a/src/presentation/config-store.ts
+++ b/src/presentation/config-store.ts
@@ -64,6 +64,20 @@ async function readPresentationConfigFile(filePath: string): Promise<Presentatio
   }
 }
 
+function serializePresentationConfigOverride(config: PresentationConfigOverride): PresentationConfigFile {
+  const presentation: NonNullable<PresentationConfigFile['presentation']> = {};
+
+  if (config.defaultMode) {
+    presentation.defaultMode = config.defaultMode;
+  }
+
+  if (Object.keys(config.tools).length > 0) {
+    presentation.tools = config.tools;
+  }
+
+  return { presentation };
+}
+
 export async function loadPresentationConfigLayers(
   options: PresentationConfigStoreOptions = {}
 ): Promise<LoadedPresentationConfig> {
@@ -85,13 +99,17 @@ export async function loadPresentationConfigLayers(
 export async function savePresentationConfigScope(
   options: PresentationConfigStoreOptions,
   scope: PresentationScope,
-  config: PresentationConfig
+  config: PresentationConfigOverride
 ) {
   const { globalPath, projectPath } = getPresentationConfigPaths(options);
   const filePath = scope === 'global' ? globalPath : projectPath;
 
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, JSON.stringify({ presentation: config }, null, 2) + '\n', 'utf8');
+  await writeFile(
+    filePath,
+    JSON.stringify(serializePresentationConfigOverride(config), null, 2) + '\n',
+    'utf8'
+  );
 }
 
 export async function resetPresentationConfigScope(

--- a/src/presentation/config.ts
+++ b/src/presentation/config.ts
@@ -1,9 +1,58 @@
-import type { PresentationConfig, PresentationMode, PresentationToolName } from './types.js';
+import {
+  PRESENTATION_MODES,
+  type PresentationConfig,
+  type PresentationConfigFile,
+  type PresentationMode,
+  type PresentationToolName
+} from './types.js';
+
+const PRESENTATION_MODE_SET = new Set<string>(PRESENTATION_MODES);
 
 export const DEFAULT_PRESENTATION_CONFIG: PresentationConfig = {
   defaultMode: 'compact',
   tools: {}
 };
+
+export function isPresentationMode(value: unknown): value is PresentationMode {
+  return typeof value === 'string' && PRESENTATION_MODE_SET.has(value);
+}
+
+export function normalizePresentationConfigFile(
+  file: PresentationConfigFile | null | undefined
+): PresentationConfig {
+  const presentation = file?.presentation;
+  const defaultMode = isPresentationMode(presentation?.defaultMode)
+    ? presentation.defaultMode
+    : DEFAULT_PRESENTATION_CONFIG.defaultMode;
+
+  const tools = Object.fromEntries(
+    Object.entries(presentation?.tools ?? {}).flatMap(([toolName, value]) => {
+      if (!value || !isPresentationMode(value.mode)) {
+        return [];
+      }
+
+      return [[toolName, { mode: value.mode }]];
+    })
+  ) as PresentationConfig['tools'];
+
+  return { defaultMode, tools };
+}
+
+export function mergePresentationConfigLayers(
+  defaults: PresentationConfig,
+  globalConfig?: PresentationConfig,
+  projectConfig?: PresentationConfig
+): PresentationConfig {
+  return {
+    defaultMode:
+      projectConfig?.defaultMode ?? globalConfig?.defaultMode ?? defaults.defaultMode,
+    tools: {
+      ...defaults.tools,
+      ...globalConfig?.tools,
+      ...projectConfig?.tools
+    }
+  };
+}
 
 export function resolvePresentationMode(
   toolName: PresentationToolName,

--- a/src/presentation/config.ts
+++ b/src/presentation/config.ts
@@ -2,6 +2,7 @@ import {
   PRESENTATION_MODES,
   type PresentationConfig,
   type PresentationConfigFile,
+  type PresentationConfigOverride,
   type PresentationMode,
   type PresentationToolName
 } from './types.js';
@@ -17,14 +18,10 @@ export function isPresentationMode(value: unknown): value is PresentationMode {
   return typeof value === 'string' && PRESENTATION_MODE_SET.has(value);
 }
 
-export function normalizePresentationConfigFile(
+export function extractPresentationConfigOverride(
   file: PresentationConfigFile | null | undefined
-): PresentationConfig {
+): PresentationConfigOverride {
   const presentation = file?.presentation;
-  const defaultMode = isPresentationMode(presentation?.defaultMode)
-    ? presentation.defaultMode
-    : DEFAULT_PRESENTATION_CONFIG.defaultMode;
-
   const tools = Object.fromEntries(
     Object.entries(presentation?.tools ?? {}).flatMap(([toolName, value]) => {
       if (!value || !isPresentationMode(value.mode)) {
@@ -35,13 +32,29 @@ export function normalizePresentationConfigFile(
     })
   ) as PresentationConfig['tools'];
 
-  return { defaultMode, tools };
+  return {
+    defaultMode: isPresentationMode(presentation?.defaultMode)
+      ? presentation.defaultMode
+      : undefined,
+    tools
+  };
+}
+
+export function normalizePresentationConfigFile(
+  file: PresentationConfigFile | null | undefined
+): PresentationConfig {
+  const override = extractPresentationConfigOverride(file);
+
+  return {
+    defaultMode: override.defaultMode ?? DEFAULT_PRESENTATION_CONFIG.defaultMode,
+    tools: override.tools
+  };
 }
 
 export function mergePresentationConfigLayers(
   defaults: PresentationConfig,
-  globalConfig?: PresentationConfig,
-  projectConfig?: PresentationConfig
+  globalConfig?: PresentationConfigOverride,
+  projectConfig?: PresentationConfigOverride
 ): PresentationConfig {
   return {
     defaultMode:

--- a/src/presentation/config.ts
+++ b/src/presentation/config.ts
@@ -2,10 +2,6 @@ import type { PresentationConfig, PresentationMode, PresentationToolName } from 
 
 export const DEFAULT_PRESENTATION_CONFIG: PresentationConfig = {
   defaultMode: 'compact',
-  allowExpansion: true,
-  preview: { maxItems: 3, maxChars: 240 },
-  verbose: { maxItems: 5 },
-  showMetrics: true,
   tools: {}
 };
 

--- a/src/presentation/config.ts
+++ b/src/presentation/config.ts
@@ -1,0 +1,17 @@
+import type { PresentationConfig, PresentationMode, PresentationToolName } from './types.js';
+
+export const DEFAULT_PRESENTATION_CONFIG: PresentationConfig = {
+  defaultMode: 'compact',
+  allowExpansion: true,
+  preview: { maxItems: 3, maxChars: 240 },
+  verbose: { maxItems: 5 },
+  showMetrics: true,
+  tools: {}
+};
+
+export function resolvePresentationMode(
+  toolName: PresentationToolName,
+  config: PresentationConfig = DEFAULT_PRESENTATION_CONFIG
+): PresentationMode {
+  return config.tools[toolName]?.mode ?? config.defaultMode;
+}

--- a/src/presentation/explore-presentation.ts
+++ b/src/presentation/explore-presentation.ts
@@ -1,0 +1,39 @@
+import type { WebExploreResponse } from '../types.js';
+import type { PresentationEnvelope } from './types.js';
+
+export function buildExplorePresentation(result: WebExploreResponse): PresentationEnvelope {
+  if (result.status === 'error') {
+    return {
+      mode: 'compact',
+      views: {
+        compact: `Research failed: ${result.error?.message ?? 'Unknown research failure.'}`
+      }
+    };
+  }
+
+  const preview = result.findings.map((finding) => `- ${finding}`).join('\n');
+  const verbose = [
+    'Findings',
+    ...result.findings.map((finding) => `- ${finding}`),
+    '',
+    'Sources',
+    ...result.sources.map((source) => `- ${source.title}: ${source.url}`),
+    result.caveat ? `\nCaveat\n${result.caveat}` : undefined
+  ]
+    .filter((line) => line !== undefined)
+    .join('\n');
+
+  return {
+    mode: 'compact',
+    views: {
+      compact: `Reviewed ${result.sources.length} sources · synthesized answer with ${result.findings.length} findings`,
+      preview,
+      verbose
+    },
+    metrics: {
+      sourceCount: result.sources.length,
+      resultCount: result.findings.length
+    },
+    sources: result.sources
+  };
+}

--- a/src/presentation/fetch-presentation.ts
+++ b/src/presentation/fetch-presentation.ts
@@ -1,0 +1,49 @@
+import type { WebFetchHeadlessResponse, WebFetchResponse } from '../types.js';
+import type { PresentationEnvelope } from './types.js';
+
+type FetchLike = WebFetchResponse | WebFetchHeadlessResponse;
+
+function countWords(text: string | undefined): number | undefined {
+  return text?.trim() ? text.trim().split(/\s+/).length : undefined;
+}
+
+function firstExcerpt(text: string | undefined, maxChars = 240): string | undefined {
+  if (!text) {
+    return undefined;
+  }
+
+  return text.length <= maxChars ? text : `${text.slice(0, maxChars).trimEnd()}…`;
+}
+
+export function buildFetchPresentation(result: FetchLike): PresentationEnvelope {
+  const wordCount = countWords(result.content?.text);
+  const compact =
+    result.status === 'ok'
+      ? `Fetched page · article extracted${wordCount ? ` · ${wordCount} words` : ''}`
+      : `Fetch failed: ${result.error?.message ?? 'Unknown fetch failure.'}`;
+
+  return {
+    mode: 'compact',
+    views: {
+      compact,
+      preview: result.content?.title
+        ? `${result.content.title}\n${firstExcerpt(result.content.text) ?? ''}`.trim()
+        : firstExcerpt(result.content?.text),
+      verbose:
+        result.status === 'ok'
+          ? [
+              `URL: ${result.url}`,
+              result.content?.title ? `Title: ${result.content.title}` : undefined,
+              firstExcerpt(result.content?.text, 500)
+            ]
+              .filter(Boolean)
+              .join('\n')
+          : undefined
+    },
+    metrics: {
+      wordCount,
+      cacheHit: result.metadata.cacheHit
+    },
+    sources: [{ title: result.content?.title ?? result.url, url: result.url }]
+  };
+}

--- a/src/presentation/fetch-presentation.ts
+++ b/src/presentation/fetch-presentation.ts
@@ -20,7 +20,9 @@ export function buildFetchPresentation(result: FetchLike): PresentationEnvelope 
   const compact =
     result.status === 'ok'
       ? `Fetched page · article extracted${wordCount ? ` · ${wordCount} words` : ''}`
-      : `Fetch failed: ${result.error?.message ?? 'Unknown fetch failure.'}`;
+      : result.status === 'needs_headless'
+        ? `Needs headless rendering: ${result.error?.message ?? 'Headless rendering recommended.'}`
+        : `Fetch failed: ${result.error?.message ?? 'Unknown fetch failure.'}`;
 
   return {
     mode: 'compact',

--- a/src/presentation/search-presentation.ts
+++ b/src/presentation/search-presentation.ts
@@ -1,0 +1,37 @@
+import type { WebSearchResponse } from '../types.js';
+import type { PresentationEnvelope } from './types.js';
+
+function formatCompact(result: WebSearchResponse): string {
+  if (result.status === 'error') {
+    return `Search failed: ${result.error?.message ?? 'Unknown search failure.'}`;
+  }
+
+  const suffix = result.results.length === 1 ? 'result' : 'results';
+  return `Found ${result.results.length} ${suffix}`;
+}
+
+export function buildSearchPresentation(result: WebSearchResponse): PresentationEnvelope {
+  const preview = result.results
+    .slice(0, 3)
+    .map((item, index) => `${index + 1}. ${item.title}`)
+    .join('\n');
+
+  const verbose = result.results
+    .slice(0, 5)
+    .map((item, index) => `${index + 1}. ${item.title}\n   ${item.url}\n   ${item.snippet}`)
+    .join('\n');
+
+  return {
+    mode: 'compact',
+    views: {
+      compact: formatCompact(result),
+      preview: preview || undefined,
+      verbose: verbose || undefined
+    },
+    metrics: {
+      resultCount: result.results.length,
+      cacheHit: result.metadata.cacheHit
+    },
+    sources: result.results.map((item) => ({ title: item.title, url: item.url }))
+  };
+}

--- a/src/presentation/select-view.ts
+++ b/src/presentation/select-view.ts
@@ -1,0 +1,20 @@
+import type { PresentationEnvelope, PresentationMode } from './types.js';
+
+export function selectPresentationView(
+  envelope: PresentationEnvelope | undefined,
+  requestedMode: PresentationMode
+): string | undefined {
+  if (!envelope) {
+    return undefined;
+  }
+
+  if (requestedMode === 'preview' && envelope.views.preview) {
+    return envelope.views.preview;
+  }
+
+  if (requestedMode === 'verbose' && envelope.views.verbose) {
+    return envelope.views.verbose;
+  }
+
+  return envelope.views.compact;
+}

--- a/src/presentation/types.ts
+++ b/src/presentation/types.ts
@@ -37,7 +37,22 @@ export type PresentationToolName =
   | 'web_fetch_headless'
   | 'web_explore';
 
+export type PresentationScope = 'global' | 'project';
+
+export type PresentationToolOverrideMode = PresentationMode;
+
+export type PresentationToolConfig = {
+  mode: PresentationToolOverrideMode;
+};
+
 export type PresentationConfig = {
   defaultMode: PresentationMode;
-  tools: Partial<Record<PresentationToolName, { mode: PresentationMode }>>;
+  tools: Partial<Record<PresentationToolName, PresentationToolConfig>>;
+};
+
+export type PresentationConfigFile = {
+  presentation?: {
+    defaultMode?: unknown;
+    tools?: Partial<Record<PresentationToolName, { mode?: unknown }>>;
+  };
 };

--- a/src/presentation/types.ts
+++ b/src/presentation/types.ts
@@ -39,9 +39,5 @@ export type PresentationToolName =
 
 export type PresentationConfig = {
   defaultMode: PresentationMode;
-  allowExpansion: boolean;
-  preview: { maxItems: number; maxChars: number };
-  verbose: { maxItems: number };
-  showMetrics: boolean;
   tools: Partial<Record<PresentationToolName, { mode: PresentationMode }>>;
 };

--- a/src/presentation/types.ts
+++ b/src/presentation/types.ts
@@ -50,6 +50,11 @@ export type PresentationConfig = {
   tools: Partial<Record<PresentationToolName, PresentationToolConfig>>;
 };
 
+export type PresentationConfigOverride = {
+  defaultMode?: PresentationMode;
+  tools: Partial<Record<PresentationToolName, PresentationToolConfig>>;
+};
+
 export type PresentationConfigFile = {
   presentation?: {
     defaultMode?: unknown;

--- a/src/presentation/types.ts
+++ b/src/presentation/types.ts
@@ -1,0 +1,47 @@
+export const PRESENTATION_MODES = ['compact', 'preview', 'verbose'] as const;
+export type PresentationMode = (typeof PRESENTATION_MODES)[number];
+
+export type PresentationViews = {
+  compact: string;
+  preview?: string;
+  verbose?: string;
+};
+
+export type PresentationMetrics = {
+  durationMs?: number;
+  resultCount?: number;
+  sourceCount?: number;
+  wordCount?: number;
+  statusCode?: number;
+  cacheHit?: boolean;
+  truncated?: boolean;
+};
+
+export type PresentationSource = {
+  title: string;
+  url: string;
+  domain?: string;
+};
+
+export type PresentationEnvelope = {
+  mode: PresentationMode;
+  views: PresentationViews;
+  metrics?: PresentationMetrics;
+  sources?: PresentationSource[];
+  debug?: Record<string, unknown>;
+};
+
+export type PresentationToolName =
+  | 'web_search'
+  | 'web_fetch'
+  | 'web_fetch_headless'
+  | 'web_explore';
+
+export type PresentationConfig = {
+  defaultMode: PresentationMode;
+  allowExpansion: boolean;
+  preview: { maxItems: number; maxChars: number };
+  verbose: { maxItems: number };
+  showMetrics: boolean;
+  tools: Partial<Record<PresentationToolName, { mode: PresentationMode }>>;
+};

--- a/src/tools/web-explore.ts
+++ b/src/tools/web-explore.ts
@@ -1,5 +1,7 @@
 import { createResearchWorkflow } from '../orchestration/index.js';
+import { buildExplorePresentation } from '../presentation/explore-presentation.js';
 import type { ResearchEvidence } from '../orchestration/research-types.js';
+import type { WebExploreResponse } from '../types.js';
 
 function findingFromEvidence(evidence: ResearchEvidence, index: number): string {
   if (evidence.summary.includes('Use channel')) {
@@ -18,22 +20,6 @@ function findingFromEvidence(evidence: ResearchEvidence, index: number): string 
   }
 
   return evidence.summary || `Finding ${index + 1}`;
-}
-
-function formatExploreText({
-  findings,
-  sources,
-  caveat
-}: {
-  findings: string[];
-  sources: Array<{ title: string; url: string }>;
-  caveat?: string;
-}) {
-  const findingLines = findings.map((finding) => `- ${finding}`).join('\n');
-  const sourceLines = sources.map((source) => `- ${source.title}: ${source.url}`).join('\n');
-  const caveatBlock = caveat ? `\n\nCaveat\n${caveat}` : '';
-
-  return `Findings\n${findingLines}\n\nSources\n${sourceLines}${caveatBlock}`;
 }
 
 export function createWebExploreTool({
@@ -59,11 +45,16 @@ export function createWebExploreTool({
     const normalizedQuery = query.trim();
 
     if (!normalizedQuery) {
-      return {
-        status: 'error' as const,
+      const result: WebExploreResponse = {
+        status: 'error',
         findings: [],
         sources: [],
         error: { code: 'INVALID_QUERY', message: 'Query must not be empty.' }
+      };
+
+      return {
+        ...result,
+        presentation: buildExplorePresentation(result)
       };
     }
 
@@ -78,12 +69,16 @@ export function createWebExploreTool({
         ? undefined
         : 'Evidence is partial, so this answer is based on the strongest source found so far.';
 
-    return {
-      status: 'ok' as const,
+    const shaped: WebExploreResponse = {
+      status: 'ok',
       findings,
       sources,
-      caveat,
-      text: formatExploreText({ findings, sources, caveat })
+      caveat
+    };
+
+    return {
+      ...shaped,
+      presentation: buildExplorePresentation(shaped)
     };
   };
 }

--- a/src/tools/web-fetch-headless.ts
+++ b/src/tools/web-fetch-headless.ts
@@ -1,4 +1,5 @@
 import { headlessFetch } from '../fetch/headless-fetch.js';
+import { buildFetchPresentation } from '../presentation/fetch-presentation.js';
 import type { WebFetchHeadlessResponse } from '../types.js';
 
 export function createWebFetchHeadlessTool({
@@ -8,14 +9,23 @@ export function createWebFetchHeadlessTool({
 } = {}) {
   return async function webFetchHeadless({ url }: { url: string }): Promise<WebFetchHeadlessResponse> {
     if (!/^https?:\/\//.test(url)) {
-      return {
+      const result: WebFetchHeadlessResponse = {
         status: 'unsupported',
         url,
         metadata: { method: 'headless', cacheHit: false },
         error: { code: 'UNSUPPORTED_URL', message: 'Only http and https URLs are supported.' }
       };
+
+      return {
+        ...result,
+        presentation: buildFetchPresentation(result)
+      };
     }
 
-    return fetchPage(url);
+    const result = await fetchPage(url);
+    return {
+      ...result,
+      presentation: buildFetchPresentation(result)
+    };
   };
 }

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -1,4 +1,5 @@
 import { createHttpFetcher } from '../fetch/http-fetch.js';
+import { buildFetchPresentation } from '../presentation/fetch-presentation.js';
 import type { WebFetchResponse } from '../types.js';
 
 export function createWebFetchTool({
@@ -8,14 +9,23 @@ export function createWebFetchTool({
 } = {}) {
   return async function webFetch({ url }: { url: string }): Promise<WebFetchResponse> {
     if (!/^https?:\/\//.test(url)) {
-      return {
+      const result: WebFetchResponse = {
         status: 'unsupported',
         url,
         metadata: { method: 'http', cacheHit: false },
         error: { code: 'UNSUPPORTED_URL', message: 'Only http and https URLs are supported.' }
       };
+
+      return {
+        ...result,
+        presentation: buildFetchPresentation(result)
+      };
     }
 
-    return fetchPage(url);
+    const result = await fetchPage(url);
+    return {
+      ...result,
+      presentation: buildFetchPresentation(result)
+    };
   };
 }

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,4 +1,5 @@
 import { createCacheKey, createTtlCache } from '../cache/ttl-cache.js';
+import { buildSearchPresentation } from '../presentation/search-presentation.js';
 import { fetchDuckDuckGoHtml, parseDuckDuckGoResults } from '../search/duckduckgo.js';
 import type { WebSearchResponse } from '../types.js';
 
@@ -53,20 +54,28 @@ export function createWebSearchTool({
     const normalizedQuery = query.trim();
 
     if (!normalizedQuery) {
-      return {
+      const result: WebSearchResponse = {
         status: 'error',
         results: [],
         metadata: { backend: 'duckduckgo', cacheHit: false },
         error: { code: 'INVALID_QUERY', message: 'Query must not be empty.' }
+      };
+      return {
+        ...result,
+        presentation: buildSearchPresentation(result)
       };
     }
 
     const cacheKey = createCacheKey(['web_search', normalizedQuery]);
     const cached = cache.get(cacheKey);
     if (cached) {
-      return {
+      const result: WebSearchResponse = {
         ...cached,
         metadata: { ...cached.metadata, cacheHit: true }
+      };
+      return {
+        ...result,
+        presentation: buildSearchPresentation(result)
       };
     }
 
@@ -81,11 +90,14 @@ export function createWebSearchTool({
           metadata: { backend: 'duckduckgo', cacheHit: false }
         };
         cache.set(cacheKey, result);
-        return result;
+        return {
+          ...result,
+          presentation: buildSearchPresentation(result)
+        };
       }
 
       if (parsed.noResults) {
-        return {
+        const result: WebSearchResponse = {
           status: 'error',
           results: [],
           metadata: { backend: 'duckduckgo', cacheHit: false },
@@ -94,10 +106,14 @@ export function createWebSearchTool({
             message: 'DuckDuckGo returned no usable results for this query.'
           }
         };
+        return {
+          ...result,
+          presentation: buildSearchPresentation(result)
+        };
       }
 
       if (htmlLooksBlocked(html)) {
-        return {
+        const result: WebSearchResponse = {
           status: 'error',
           results: [],
           metadata: { backend: 'duckduckgo', cacheHit: false },
@@ -106,9 +122,13 @@ export function createWebSearchTool({
             message: 'DuckDuckGo search appears to be blocked or rate limited.'
           }
         };
+        return {
+          ...result,
+          presentation: buildSearchPresentation(result)
+        };
       }
 
-      return {
+      const result: WebSearchResponse = {
         status: 'error',
         results: [],
         metadata: { backend: 'duckduckgo', cacheHit: false },
@@ -117,12 +137,20 @@ export function createWebSearchTool({
           message: 'DuckDuckGo returned a page, but it did not match the expected results format.'
         }
       };
-    } catch (error) {
       return {
+        ...result,
+        presentation: buildSearchPresentation(result)
+      };
+    } catch (error) {
+      const result: WebSearchResponse = {
         status: 'error',
         results: [],
         metadata: { backend: 'duckduckgo', cacheHit: false },
         error: classifySearchFailure(error)
+      };
+      return {
+        ...result,
+        presentation: buildSearchPresentation(result)
       };
     }
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { PresentationEnvelope } from './presentation/types.js';
+
 export const TOOL_STATUSES = [
   'ok',
   'needs_headless',
@@ -43,6 +45,7 @@ export type WebSearchResponse = {
   status: 'ok' | 'error';
   results: SearchResult[];
   metadata: SearchMetadata;
+  presentation?: PresentationEnvelope;
   error?: ToolError;
 };
 
@@ -51,6 +54,7 @@ export type WebFetchResponse = {
   url: string;
   content?: ExtractedContent;
   metadata: FetchMetadata;
+  presentation?: PresentationEnvelope;
   error?: ToolError;
 };
 
@@ -59,5 +63,15 @@ export type WebFetchHeadlessResponse = {
   url: string;
   content?: ExtractedContent;
   metadata: FetchMetadata;
+  presentation?: PresentationEnvelope;
+  error?: ToolError;
+};
+
+export type WebExploreResponse = {
+  status: 'ok' | 'error';
+  findings: string[];
+  sources: Array<{ title: string; url: string }>;
+  caveat?: string;
+  presentation?: PresentationEnvelope;
   error?: ToolError;
 };

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -173,4 +173,100 @@ describe('web-agent config commands', () => {
 
     expect(reset).toHaveBeenCalledWith('project');
   });
+
+  it('sets the default mode in project scope when given a single mode token', async () => {
+    let handler: any;
+    const save = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: {
+          path: '/project/config.json',
+          exists: false,
+          rawConfig: { defaultMode: 'compact', tools: {} }
+        },
+        effectiveConfig: { defaultMode: 'compact', tools: {} }
+      }),
+      save,
+      reset: vi.fn()
+    });
+
+    await handler('mode preview', { ui: { notify: vi.fn() } });
+
+    expect(save).toHaveBeenCalledWith('project', {
+      defaultMode: 'preview',
+      tools: {}
+    });
+  });
+
+  it('sets a per-tool override when given tool name plus mode', async () => {
+    let handler: any;
+    const save = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: {
+          path: '/project/config.json',
+          exists: true,
+          rawConfig: { defaultMode: 'compact', tools: {} }
+        },
+        effectiveConfig: { defaultMode: 'compact', tools: {} }
+      }),
+      save,
+      reset: vi.fn()
+    });
+
+    await handler('mode web_search verbose', { ui: { notify: vi.fn() } });
+
+    expect(save).toHaveBeenCalledWith('project', {
+      defaultMode: 'compact',
+      tools: { web_search: { mode: 'verbose' } }
+    });
+  });
+
+  it('clears a per-tool override when inherit is requested', async () => {
+    let handler: any;
+    const save = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: {
+          path: '/project/config.json',
+          exists: true,
+          rawConfig: { defaultMode: 'compact', tools: { web_search: { mode: 'preview' } } }
+        },
+        effectiveConfig: {
+          defaultMode: 'compact',
+          tools: { web_search: { mode: 'preview' } }
+        }
+      }),
+      save,
+      reset: vi.fn()
+    });
+
+    await handler('mode web_search inherit', { ui: { notify: vi.fn() } });
+
+    expect(save).toHaveBeenCalledWith('project', {
+      defaultMode: 'compact',
+      tools: {}
+    });
+  });
 });

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -68,4 +68,109 @@ describe('web-agent config commands', () => {
     expect(reset).toHaveBeenCalledWith('project');
     expect(notify).toHaveBeenCalledWith(expect.stringContaining('Reset project config'), 'success');
   });
+
+  it('opens a custom settings UI when invoked with settings', async () => {
+    let handler: any;
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: { path: '/project/config.json', exists: false },
+        effectiveConfig: { defaultMode: 'compact', tools: {} }
+      }),
+      save: vi.fn(),
+      reset: vi.fn()
+    });
+
+    const custom = vi.fn().mockResolvedValue({
+      scope: 'project',
+      config: {
+        defaultMode: 'preview',
+        tools: { web_search: { mode: 'verbose' } }
+      },
+      action: 'save'
+    });
+
+    await handler('settings', { ui: { custom, notify: vi.fn() } });
+
+    expect(custom).toHaveBeenCalledOnce();
+  });
+
+  it('saves the selected scope and config returned by the settings ui', async () => {
+    let handler: any;
+    const save = vi.fn();
+    const notify = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: { path: '/project/config.json', exists: false },
+        effectiveConfig: { defaultMode: 'compact', tools: {} }
+      }),
+      save,
+      reset: vi.fn()
+    });
+
+    await handler('settings', {
+      ui: {
+        custom: vi.fn().mockResolvedValue({
+          action: 'save',
+          scope: 'global',
+          config: {
+            defaultMode: 'verbose',
+            tools: { web_explore: { mode: 'preview' } }
+          }
+        }),
+        notify
+      }
+    });
+
+    expect(save).toHaveBeenCalledWith('global', {
+      defaultMode: 'verbose',
+      tools: { web_explore: { mode: 'preview' } }
+    });
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Saved global config'), 'success');
+  });
+
+  it('resets the selected scope when the settings ui returns reset', async () => {
+    let handler: any;
+    const reset = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: true },
+        project: { path: '/project/config.json', exists: true },
+        effectiveConfig: { defaultMode: 'compact', tools: {} }
+      }),
+      save: vi.fn(),
+      reset
+    });
+
+    await handler('settings', {
+      ui: {
+        custom: vi.fn().mockResolvedValue({
+          action: 'reset',
+          scope: 'project'
+        }),
+        notify: vi.fn()
+      }
+    });
+
+    expect(reset).toHaveBeenCalledWith('project');
+  });
 });

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -146,6 +146,38 @@ describe('web-agent config commands', () => {
     expect(notify).toHaveBeenCalledWith(expect.stringContaining('Reset project config'), 'info');
   });
 
+  it('opens a custom settings UI when invoked with no args', async () => {
+    let handler: any;
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: { path: '/project/config.json', exists: false },
+        effectiveConfig: { defaultMode: 'compact', tools: {} }
+      }),
+      save: vi.fn(),
+      reset: vi.fn()
+    });
+
+    const custom = vi.fn().mockResolvedValue({
+      scope: 'project',
+      config: {
+        defaultMode: 'preview',
+        tools: { web_search: { mode: 'verbose' } }
+      },
+      action: 'save'
+    });
+
+    await handler('', { ui: { custom, notify: vi.fn() } });
+
+    expect(custom).toHaveBeenCalledOnce();
+  });
+
   it('opens a custom settings UI when invoked with settings', async () => {
     let handler: any;
     const pi = {

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -66,7 +66,7 @@ describe('web-agent config commands', () => {
     await handler('reset project', { ui: { notify } });
 
     expect(reset).toHaveBeenCalledWith('project');
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Reset project config'), 'success');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Reset project config'), 'info');
   });
 
   it('opens a custom settings UI when invoked with settings', async () => {
@@ -139,7 +139,7 @@ describe('web-agent config commands', () => {
       defaultMode: 'verbose',
       tools: { web_explore: { mode: 'preview' } }
     });
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Saved global config'), 'success');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Saved global config'), 'info');
   });
 
   it('resets the selected scope when the settings ui returns reset', async () => {

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerWebAgentConfigCommands } from '../../src/commands/web-agent-config.js';
+
+describe('web-agent config commands', () => {
+  it('registers a single /web-agent command', () => {
+    const pi = { registerCommand: vi.fn() };
+
+    registerWebAgentConfigCommands(pi as never);
+
+    expect(pi.registerCommand).toHaveBeenCalledWith(
+      'web-agent',
+      expect.objectContaining({ handler: expect.any(Function) })
+    );
+  });
+
+  it('renders effective config from the store for show', async () => {
+    let handler: any;
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: {
+          path: '/global/config.json',
+          exists: true,
+          rawConfig: { defaultMode: 'preview', tools: {} }
+        },
+        project: {
+          path: '/project/config.json',
+          exists: true,
+          rawConfig: { defaultMode: 'preview', tools: { web_search: { mode: 'verbose' } } }
+        },
+        effectiveConfig: {
+          defaultMode: 'preview',
+          tools: { web_search: { mode: 'verbose' } }
+        }
+      }),
+      reset: vi.fn()
+    });
+
+    const notify = vi.fn();
+    await handler('show', { ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('defaultMode: preview'), 'info');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('web_search: verbose'), 'info');
+  });
+
+  it('resets project scope when explicitly requested', async () => {
+    let handler: any;
+    const reset = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn(),
+      reset
+    });
+
+    const notify = vi.fn();
+    await handler('reset project', { ui: { notify } });
+
+    expect(reset).toHaveBeenCalledWith('project');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Reset project config'), 'success');
+  });
+});

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -1,5 +1,82 @@
 import { describe, expect, it, vi } from 'vitest';
-import { registerWebAgentConfigCommands } from '../../src/commands/web-agent-config.js';
+import {
+  applySettingsValue,
+  collapsePresentationConfigToOverride,
+  createSettingsDraftState,
+  handleSettingsShortcut,
+  registerWebAgentConfigCommands
+} from '../../src/commands/web-agent-config.js';
+import { DEFAULT_PRESENTATION_CONFIG, mergePresentationConfigLayers } from '../../src/presentation/config.js';
+
+describe('web-agent config draft helpers', () => {
+  it('switches to the selected scope draft instead of keeping the old scope values', () => {
+    const loaded = {
+      global: {
+        path: '/global/config.json',
+        exists: true,
+        rawConfig: {
+          defaultMode: 'preview' as const,
+          tools: { web_explore: { mode: 'verbose' as const } }
+        }
+      },
+      project: {
+        path: '/project/config.json',
+        exists: true,
+        rawConfig: {
+          tools: { web_search: { mode: 'compact' as const } }
+        }
+      },
+      effectiveConfig: mergePresentationConfigLayers(
+        DEFAULT_PRESENTATION_CONFIG,
+        {
+          defaultMode: 'preview',
+          tools: { web_explore: { mode: 'verbose' } }
+        },
+        {
+          tools: { web_search: { mode: 'compact' } }
+        }
+      )
+    };
+
+    const initialState = createSettingsDraftState(loaded, 'project');
+    const switchedState = applySettingsValue(initialState, 'scope', 'global');
+
+    expect(initialState.scope).toBe('project');
+    expect(initialState.config).toEqual({
+      defaultMode: 'preview',
+      tools: { web_explore: { mode: 'verbose' }, web_search: { mode: 'compact' } }
+    });
+    expect(switchedState.scope).toBe('global');
+    expect(switchedState.config).toEqual({
+      defaultMode: 'preview',
+      tools: { web_explore: { mode: 'verbose' } }
+    });
+  });
+
+  it('collapses inherited values instead of materializing them into the saved override', () => {
+    expect(
+      collapsePresentationConfigToOverride(
+        {
+          defaultMode: 'preview',
+          tools: { web_search: { mode: 'verbose' } }
+        },
+        {
+          defaultMode: 'preview',
+          tools: {}
+        }
+      )
+    ).toEqual({
+      tools: { web_search: { mode: 'verbose' } }
+    });
+  });
+
+  it('supports real cancel and reset shortcuts in the settings UI', () => {
+    expect(handleSettingsShortcut('\u001b')).toEqual({ action: 'cancel' });
+    expect(handleSettingsShortcut('\u0012')).toEqual({ action: 'reset' });
+    expect(handleSettingsShortcut('\u0013')).toEqual({ action: 'save' });
+    expect(handleSettingsShortcut('x')).toBeUndefined();
+  });
+});
 
 describe('web-agent config commands', () => {
   it('registers a single /web-agent command', () => {
@@ -101,7 +178,7 @@ describe('web-agent config commands', () => {
     expect(custom).toHaveBeenCalledOnce();
   });
 
-  it('saves the selected scope and config returned by the settings ui', async () => {
+  it('saves sparse project overrides from settings instead of copying inherited defaults', async () => {
     let handler: any;
     const save = vi.fn();
     const notify = vi.fn();
@@ -113,9 +190,13 @@ describe('web-agent config commands', () => {
 
     registerWebAgentConfigCommands(pi as never, {
       load: vi.fn().mockResolvedValue({
-        global: { path: '/global/config.json', exists: false },
+        global: {
+          path: '/global/config.json',
+          exists: true,
+          rawConfig: { defaultMode: 'preview', tools: {} }
+        },
         project: { path: '/project/config.json', exists: false },
-        effectiveConfig: { defaultMode: 'compact', tools: {} }
+        effectiveConfig: { defaultMode: 'preview', tools: {} }
       }),
       save,
       reset: vi.fn()
@@ -125,21 +206,20 @@ describe('web-agent config commands', () => {
       ui: {
         custom: vi.fn().mockResolvedValue({
           action: 'save',
-          scope: 'global',
+          scope: 'project',
           config: {
-            defaultMode: 'verbose',
-            tools: { web_explore: { mode: 'preview' } }
+            defaultMode: 'preview',
+            tools: { web_explore: { mode: 'verbose' } }
           }
         }),
         notify
       }
     });
 
-    expect(save).toHaveBeenCalledWith('global', {
-      defaultMode: 'verbose',
-      tools: { web_explore: { mode: 'preview' } }
+    expect(save).toHaveBeenCalledWith('project', {
+      tools: { web_explore: { mode: 'verbose' } }
     });
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Saved global config'), 'info');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Saved project config'), 'info');
   });
 
   it('resets the selected scope when the settings ui returns reset', async () => {
@@ -174,7 +254,7 @@ describe('web-agent config commands', () => {
     expect(reset).toHaveBeenCalledWith('project');
   });
 
-  it('sets the default mode in project scope when given a single mode token', async () => {
+  it('sets the default mode in project scope without pinning the inherited global default', async () => {
     let handler: any;
     const save = vi.fn();
     const pi = {
@@ -185,13 +265,16 @@ describe('web-agent config commands', () => {
 
     registerWebAgentConfigCommands(pi as never, {
       load: vi.fn().mockResolvedValue({
-        global: { path: '/global/config.json', exists: false },
+        global: {
+          path: '/global/config.json',
+          exists: true,
+          rawConfig: { defaultMode: 'preview', tools: {} }
+        },
         project: {
           path: '/project/config.json',
-          exists: false,
-          rawConfig: { defaultMode: 'compact', tools: {} }
+          exists: false
         },
-        effectiveConfig: { defaultMode: 'compact', tools: {} }
+        effectiveConfig: { defaultMode: 'preview', tools: {} }
       }),
       save,
       reset: vi.fn()
@@ -200,7 +283,6 @@ describe('web-agent config commands', () => {
     await handler('mode preview', { ui: { notify: vi.fn() } });
 
     expect(save).toHaveBeenCalledWith('project', {
-      defaultMode: 'preview',
       tools: {}
     });
   });
@@ -231,7 +313,6 @@ describe('web-agent config commands', () => {
     await handler('mode web_search verbose', { ui: { notify: vi.fn() } });
 
     expect(save).toHaveBeenCalledWith('project', {
-      defaultMode: 'compact',
       tools: { web_search: { mode: 'verbose' } }
     });
   });
@@ -265,7 +346,6 @@ describe('web-agent config commands', () => {
     await handler('mode web_search inherit', { ui: { notify: vi.fn() } });
 
     expect(save).toHaveBeenCalledWith('project', {
-      defaultMode: 'compact',
       tools: {}
     });
   });

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -30,13 +30,9 @@ describe('presentation contracts', () => {
     expect(DEFAULT_PRESENTATION_CONFIG.defaultMode).toBe('compact');
   });
 
-  it('allows per-tool mode overrides', () => {
+  it('allows per-tool mode overrides without exposing inactive config fields', () => {
     const config: PresentationConfig = {
       defaultMode: 'compact',
-      allowExpansion: true,
-      preview: { maxItems: 3, maxChars: 240 },
-      verbose: { maxItems: 5 },
-      showMetrics: true,
       tools: {
         web_search: { mode: 'preview' }
       }

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, it } from 'vitest';
 import type {
   PresentationEnvelope,
   PresentationMode,
-  PresentationConfig
+  PresentationConfig,
+  PresentationConfigFile,
+  PresentationToolOverrideMode
 } from '../src/presentation/types.js';
-import { DEFAULT_PRESENTATION_CONFIG } from '../src/presentation/config.js';
+import {
+  DEFAULT_PRESENTATION_CONFIG,
+  mergePresentationConfigLayers,
+  normalizePresentationConfigFile,
+  resolvePresentationMode
+} from '../src/presentation/config.js';
 import {
   TOOL_STATUSES,
   type ToolStatus,
@@ -30,15 +37,74 @@ describe('presentation contracts', () => {
     expect(DEFAULT_PRESENTATION_CONFIG.defaultMode).toBe('compact');
   });
 
-  it('allows per-tool mode overrides without exposing inactive config fields', () => {
+  it('treats missing tool overrides as inherit', () => {
     const config: PresentationConfig = {
+      defaultMode: 'preview',
+      tools: {}
+    };
+
+    expect(resolvePresentationMode('web_fetch', config)).toBe('preview');
+  });
+
+  it('normalizes a config file with valid overrides', () => {
+    const file: PresentationConfigFile = {
+      presentation: {
+        defaultMode: 'verbose',
+        tools: {
+          web_search: { mode: 'preview' },
+          web_fetch: { mode: 'compact' }
+        }
+      }
+    };
+
+    expect(normalizePresentationConfigFile(file)).toEqual({
+      defaultMode: 'verbose',
+      tools: {
+        web_search: { mode: 'preview' },
+        web_fetch: { mode: 'compact' }
+      }
+    });
+  });
+
+  it('merges defaults, then global, then project', () => {
+    expect(
+      mergePresentationConfigLayers(
+        { defaultMode: 'compact', tools: {} },
+        {
+          defaultMode: 'preview',
+          tools: { web_explore: { mode: 'verbose' } }
+        },
+        {
+          defaultMode: 'preview',
+          tools: { web_search: { mode: 'compact' } }
+        }
+      )
+    ).toEqual({
+      defaultMode: 'preview',
+      tools: {
+        web_explore: { mode: 'verbose' },
+        web_search: { mode: 'compact' }
+      }
+    });
+  });
+
+  it('filters invalid tool override values instead of crashing', () => {
+    const normalized = normalizePresentationConfigFile({
+      presentation: {
+        defaultMode: 'compact',
+        tools: {
+          web_search: { mode: 'preview' },
+          web_fetch: { mode: 'loud' as PresentationToolOverrideMode }
+        }
+      }
+    });
+
+    expect(normalized).toEqual({
       defaultMode: 'compact',
       tools: {
         web_search: { mode: 'preview' }
       }
-    };
-
-    expect(config.tools.web_search?.mode).toBe('preview');
+    });
   });
 });
 

--- a/tests/contracts.test.ts
+++ b/tests/contracts.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import type {
+  PresentationEnvelope,
+  PresentationMode,
+  PresentationConfig
+} from '../src/presentation/types.js';
+import { DEFAULT_PRESENTATION_CONFIG } from '../src/presentation/config.js';
 import {
   TOOL_STATUSES,
   type ToolStatus,
@@ -8,6 +14,37 @@ import {
   type WebFetchHeadlessResponse
 } from '../src/types.js';
 import extension from '../src/extension.js';
+
+describe('presentation contracts', () => {
+  it('defines compact as the default mode and exposes all supported modes', () => {
+    const envelope: PresentationEnvelope = {
+      mode: 'compact',
+      views: {
+        compact: 'Found 2 results in 0.2s',
+        preview: '1. Example',
+        verbose: 'Top results (2)\n1. Example'
+      }
+    };
+
+    expect(envelope.mode satisfies PresentationMode).toBe('compact');
+    expect(DEFAULT_PRESENTATION_CONFIG.defaultMode).toBe('compact');
+  });
+
+  it('allows per-tool mode overrides', () => {
+    const config: PresentationConfig = {
+      defaultMode: 'compact',
+      allowExpansion: true,
+      preview: { maxItems: 3, maxChars: 240 },
+      verbose: { maxItems: 5 },
+      showMetrics: true,
+      tools: {
+        web_search: { mode: 'preview' }
+      }
+    };
+
+    expect(config.tools.web_search?.mode).toBe('preview');
+  });
+});
 
 describe('shared tool contracts', () => {
   it('exposes the allowed tool statuses', () => {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -102,7 +102,7 @@ describe('Pi extension entrypoint', () => {
     expect(handlers.has('context')).toBe(false);
   });
 
-  it('returns human-readable content for web_explore instead of only raw json', async () => {
+  it('returns compact output for web_explore by default instead of the old text block', async () => {
     const tools: any[] = [];
     const pi = {
       registerTool: (tool: any) => tools.push(tool),
@@ -116,8 +116,51 @@ describe('Pi extension entrypoint', () => {
       query: 'example query'
     });
 
-    expect(result.content[0].text).toContain('Findings');
-    expect(result.content[0].text).toContain('Sources');
+    expect(result.content[0].text).toContain('Reviewed');
+    expect(result.content[0].text).not.toContain('Findings\n');
+    expect(result.content[0].text).not.toContain('{\n');
+  }, 15000);
+
+  it('returns compact output for web_search by default instead of raw json', async () => {
+    const tools: any[] = [];
+    const pi = {
+      registerTool: (tool: any) => tools.push(tool),
+      on: vi.fn()
+    };
+
+    extension(pi as never);
+
+    const webSearch = tools.find((tool) => tool.name === 'web_search');
+    const result = await webSearch.execute('tool-call-1', { query: 'plain search' });
+
+    expect(result.content[0].text).toContain('Found');
+    expect(result.content[0].text).not.toContain('{\n');
+  }, 15000);
+
+  it('can render preview mode when web_search is configured for preview', async () => {
+    const tools: any[] = [];
+    const pi = {
+      registerTool: (tool: any) => tools.push(tool),
+      on: vi.fn(),
+      getConfig: () => ({
+        presentation: {
+          defaultMode: 'compact',
+          allowExpansion: true,
+          preview: { maxItems: 3, maxChars: 240 },
+          verbose: { maxItems: 5 },
+          showMetrics: true,
+          tools: { web_search: { mode: 'preview' } }
+        }
+      })
+    };
+
+    extension(pi as never);
+
+    const webSearch = tools.find((tool) => tool.name === 'web_search');
+    const result = await webSearch.execute('tool-call-1', { query: 'plain search' });
+
+    expect(result.content[0].text).toContain('1.');
+    expect(result.content[0].text).not.toContain('Found 1 result');
   }, 15000);
 
   it('blocks low-level web_search after a successful web_explore in the same tool flow', async () => {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -145,10 +145,6 @@ describe('Pi extension entrypoint', () => {
       getConfig: () => ({
         presentation: {
           defaultMode: 'compact',
-          allowExpansion: true,
-          preview: { maxItems: 3, maxChars: 240 },
-          verbose: { maxItems: 5 },
-          showMetrics: true,
           tools: { web_search: { mode: 'preview' } }
         }
       })

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -2,9 +2,24 @@ import { describe, expect, it, vi } from 'vitest';
 import extension from '../src/extension.js';
 
 describe('Pi extension entrypoint', () => {
+  it('registers the web-agent config commands', () => {
+    const pi = {
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn()
+    };
+
+    extension(pi as never);
+
+    expect(pi.registerCommand).toHaveBeenCalledWith(
+      'web-agent',
+      expect.objectContaining({ description: expect.stringContaining('settings') })
+    );
+  });
+
   it('registers four tools with Pi', () => {
     const registerTool = vi.fn();
-    const pi = { registerTool, on: vi.fn() };
+    const pi = { registerTool, registerCommand: vi.fn(), on: vi.fn() };
 
     extension(pi as never);
 
@@ -19,7 +34,7 @@ describe('Pi extension entrypoint', () => {
 
   it('describes web_explore as the preferred tool for research-style web questions', () => {
     const registerTool = vi.fn();
-    const pi = { registerTool, on: vi.fn() };
+    const pi = { registerTool, registerCommand: vi.fn(), on: vi.fn() };
 
     extension(pi as never);
 
@@ -36,7 +51,7 @@ describe('Pi extension entrypoint', () => {
 
   it('describes low-level tools as direct/manual tools and points research prompts to web_explore', () => {
     const registerTool = vi.fn();
-    const pi = { registerTool, on: vi.fn() };
+    const pi = { registerTool, registerCommand: vi.fn(), on: vi.fn() };
 
     extension(pi as never);
 
@@ -59,6 +74,7 @@ describe('Pi extension entrypoint', () => {
     const handlers = new Map<string, Function>();
     const pi = {
       registerTool: vi.fn(),
+      registerCommand: vi.fn(),
       on: vi.fn((eventName: string, handler: Function) => {
         handlers.set(eventName, handler);
       })
@@ -84,14 +100,19 @@ describe('Pi extension entrypoint', () => {
     expect(result.systemPrompt).toContain(
       'Use web_search, web_fetch, and web_fetch_headless for direct/manual operations'
     );
-    expect(result.systemPrompt).toContain('After using web_explore, only call low-level web tools if there is a specific unresolved gap');
-    expect(result.systemPrompt).toContain('Do not keep searching or fetching just for extra confirmation');
+    expect(result.systemPrompt).toContain(
+      'After using web_explore, only call low-level web tools if there is a specific unresolved gap'
+    );
+    expect(result.systemPrompt).toContain(
+      'Do not keep searching or fetching just for extra confirmation'
+    );
   });
 
   it('does not register a context hook that injects reminder text into the visible session', () => {
     const handlers = new Map<string, Function>();
     const pi = {
       registerTool: vi.fn(),
+      registerCommand: vi.fn(),
       on: vi.fn((eventName: string, handler: Function) => {
         handlers.set(eventName, handler);
       })
@@ -106,6 +127,7 @@ describe('Pi extension entrypoint', () => {
     const tools: any[] = [];
     const pi = {
       registerTool: (tool: any) => tools.push(tool),
+      registerCommand: vi.fn(),
       on: vi.fn()
     };
 
@@ -125,6 +147,7 @@ describe('Pi extension entrypoint', () => {
     const tools: any[] = [];
     const pi = {
       registerTool: (tool: any) => tools.push(tool),
+      registerCommand: vi.fn(),
       on: vi.fn()
     };
 
@@ -137,17 +160,20 @@ describe('Pi extension entrypoint', () => {
     expect(result.content[0].text).not.toContain('{\n');
   }, 15000);
 
-  it('can render preview mode when web_search is configured for preview', async () => {
+  it('prefers project config over global config for rendered output', async () => {
     const tools: any[] = [];
     const pi = {
       registerTool: (tool: any) => tools.push(tool),
+      registerCommand: vi.fn(),
       on: vi.fn(),
-      getConfig: () => ({
-        presentation: {
-          defaultMode: 'compact',
-          tools: { web_search: { mode: 'preview' } }
-        }
-      })
+      __presentationConfigStore: {
+        load: vi.fn().mockResolvedValue({
+          effectiveConfig: {
+            defaultMode: 'compact',
+            tools: { web_search: { mode: 'preview' } }
+          }
+        })
+      }
     };
 
     extension(pi as never);
@@ -159,10 +185,30 @@ describe('Pi extension entrypoint', () => {
     expect(result.content[0].text).not.toContain('Found 1 result');
   }, 15000);
 
+  it('falls back to built-in defaults when the store cannot load config', async () => {
+    const tools: any[] = [];
+    const pi = {
+      registerTool: (tool: any) => tools.push(tool),
+      registerCommand: vi.fn(),
+      on: vi.fn(),
+      __presentationConfigStore: {
+        load: vi.fn().mockRejectedValue(new Error('boom'))
+      }
+    };
+
+    extension(pi as never);
+
+    const webSearch = tools.find((tool) => tool.name === 'web_search');
+    const result = await webSearch.execute('tool-call-1', { query: 'plain search' });
+
+    expect(result.content[0].text).toContain('Found');
+  }, 15000);
+
   it('blocks low-level web_search after a successful web_explore in the same tool flow', async () => {
     const tools: any[] = [];
     const pi = {
       registerTool: (tool: any) => tools.push(tool),
+      registerCommand: vi.fn(),
       on: vi.fn()
     };
 
@@ -189,6 +235,7 @@ describe('Pi extension entrypoint', () => {
     const tools: any[] = [];
     const pi = {
       registerTool: (tool: any) => tools.push(tool),
+      registerCommand: vi.fn(),
       on: vi.fn()
     };
 

--- a/tests/presentation/config-store.test.ts
+++ b/tests/presentation/config-store.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  getPresentationConfigPaths,
+  loadPresentationConfigLayers,
+  resetPresentationConfigScope,
+  savePresentationConfigScope
+} from '../../src/presentation/config-store.js';
+
+describe('presentation config store', () => {
+  let tempRoot: string;
+  let homeDir: string;
+  let projectDir: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'pi-web-agent-config-'));
+    homeDir = path.join(tempRoot, 'home');
+    projectDir = path.join(tempRoot, 'project');
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('builds the expected global and project file paths', () => {
+    expect(getPresentationConfigPaths({ homeDir, projectDir })).toEqual({
+      globalPath: path.join(homeDir, '.pi', 'agent', 'extensions', 'pi-web-agent', 'config.json'),
+      projectPath: path.join(projectDir, '.pi', 'extensions', 'pi-web-agent', 'config.json')
+    });
+  });
+
+  it('loads defaults when no files exist', async () => {
+    const loaded = await loadPresentationConfigLayers({ homeDir, projectDir });
+
+    expect(loaded.effectiveConfig).toEqual({
+      defaultMode: 'compact',
+      tools: {}
+    });
+    expect(loaded.global.exists).toBe(false);
+    expect(loaded.project.exists).toBe(false);
+  });
+
+  it('merges global and project files with project taking precedence', async () => {
+    const { globalPath, projectPath } = getPresentationConfigPaths({ homeDir, projectDir });
+
+    mkdirSync(path.dirname(globalPath), { recursive: true });
+    mkdirSync(path.dirname(projectPath), { recursive: true });
+
+    writeFileSync(
+      globalPath,
+      JSON.stringify(
+        {
+          presentation: {
+            defaultMode: 'preview',
+            tools: { web_explore: { mode: 'verbose' } }
+          }
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    writeFileSync(
+      projectPath,
+      JSON.stringify(
+        {
+          presentation: {
+            tools: { web_search: { mode: 'compact' } }
+          }
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const loaded = await loadPresentationConfigLayers({ homeDir, projectDir });
+
+    expect(loaded.effectiveConfig).toEqual({
+      defaultMode: 'preview',
+      tools: {
+        web_explore: { mode: 'verbose' },
+        web_search: { mode: 'compact' }
+      }
+    });
+  });
+
+  it('ignores invalid json instead of throwing', async () => {
+    const { globalPath } = getPresentationConfigPaths({ homeDir, projectDir });
+    mkdirSync(path.dirname(globalPath), { recursive: true });
+    writeFileSync(globalPath, '{ not-json', 'utf8');
+
+    const loaded = await loadPresentationConfigLayers({ homeDir, projectDir });
+
+    expect(loaded.effectiveConfig.defaultMode).toBe('compact');
+    expect(loaded.global.error).toContain('JSON');
+  });
+
+  it('writes only the selected scope file', async () => {
+    await savePresentationConfigScope(
+      { homeDir, projectDir },
+      'project',
+      {
+        defaultMode: 'preview',
+        tools: { web_search: { mode: 'verbose' } }
+      }
+    );
+
+    const loaded = await loadPresentationConfigLayers({ homeDir, projectDir });
+    expect(loaded.project.exists).toBe(true);
+    expect(loaded.global.exists).toBe(false);
+    expect(loaded.effectiveConfig.defaultMode).toBe('preview');
+  });
+
+  it('removes the selected scope file on reset', async () => {
+    await savePresentationConfigScope(
+      { homeDir, projectDir },
+      'project',
+      { defaultMode: 'preview', tools: {} }
+    );
+
+    await resetPresentationConfigScope({ homeDir, projectDir }, 'project');
+
+    const loaded = await loadPresentationConfigLayers({ homeDir, projectDir });
+    expect(loaded.project.exists).toBe(false);
+  });
+});

--- a/tests/presentation/config-store.test.ts
+++ b/tests/presentation/config-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -113,6 +113,25 @@ describe('presentation config store', () => {
     expect(loaded.project.exists).toBe(true);
     expect(loaded.global.exists).toBe(false);
     expect(loaded.effectiveConfig.defaultMode).toBe('preview');
+  });
+
+  it('writes sparse override json without serializing missing fields', async () => {
+    const { projectPath } = getPresentationConfigPaths({ homeDir, projectDir });
+
+    await savePresentationConfigScope(
+      { homeDir, projectDir },
+      'project',
+      {
+        tools: { web_search: { mode: 'verbose' } }
+      }
+    );
+
+    const written = JSON.parse(readFileSync(projectPath, 'utf8'));
+    expect(written).toEqual({
+      presentation: {
+        tools: { web_search: { mode: 'verbose' } }
+      }
+    });
   });
 
   it('removes the selected scope file on reset', async () => {

--- a/tests/presentation/explore-presentation.test.ts
+++ b/tests/presentation/explore-presentation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildExplorePresentation } from '../../src/presentation/explore-presentation.js';
+
+describe('buildExplorePresentation', () => {
+  it('builds one compact body plus richer optional views', () => {
+    const presentation = buildExplorePresentation({
+      status: 'ok',
+      findings: ['Use channel', 'Treat executablePath as fallback'],
+      sources: [
+        { title: 'Browsers | Playwright', url: 'https://playwright.dev/docs/browsers' },
+        { title: 'BrowserType | Playwright', url: 'https://playwright.dev/docs/api/class-browsertype' }
+      ],
+      caveat: undefined
+    });
+
+    expect(presentation.views.compact).toBe('Reviewed 2 sources · synthesized answer with 2 findings');
+    expect(presentation.views.preview).toContain('- Use channel');
+    expect(presentation.views.verbose).toContain('Sources');
+  });
+
+  it('keeps invalid-query errors concise', () => {
+    const presentation = buildExplorePresentation({
+      status: 'error',
+      findings: [],
+      sources: [],
+      error: { code: 'INVALID_QUERY', message: 'Query must not be empty.' }
+    });
+
+    expect(presentation.views.compact).toBe('Research failed: Query must not be empty.');
+  });
+});

--- a/tests/presentation/fetch-presentation.test.ts
+++ b/tests/presentation/fetch-presentation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { buildFetchPresentation } from '../../src/presentation/fetch-presentation.js';
+
+describe('buildFetchPresentation', () => {
+  it('builds a compact fetch summary and bounded richer views', () => {
+    const presentation = buildFetchPresentation({
+      status: 'ok',
+      url: 'https://example.com',
+      content: { title: 'Example title', text: 'First paragraph. Second paragraph.' },
+      metadata: { method: 'http', cacheHit: false }
+    });
+
+    expect(presentation.views.compact).toBe('Fetched page · article extracted · 4 words');
+    expect(presentation.views.preview).toContain('Example title');
+    expect(presentation.views.verbose).toContain('https://example.com');
+  });
+
+  it('keeps unsupported responses concise', () => {
+    const presentation = buildFetchPresentation({
+      status: 'unsupported',
+      url: 'file:///tmp/test.html',
+      metadata: { method: 'http', cacheHit: false },
+      error: { code: 'UNSUPPORTED_URL', message: 'Only http and https URLs are supported.' }
+    });
+
+    expect(presentation.views.compact).toBe('Fetch failed: Only http and https URLs are supported.');
+  });
+});

--- a/tests/presentation/fetch-presentation.test.ts
+++ b/tests/presentation/fetch-presentation.test.ts
@@ -25,4 +25,17 @@ describe('buildFetchPresentation', () => {
 
     expect(presentation.views.compact).toBe('Fetch failed: Only http and https URLs are supported.');
   });
+
+  it('renders needs_headless as an escalation instead of a failure', () => {
+    const presentation = buildFetchPresentation({
+      status: 'needs_headless',
+      url: 'https://example.com',
+      metadata: { method: 'http', cacheHit: false },
+      error: { code: 'WEAK_EXTRACTION', message: 'not enough content' }
+    });
+
+    expect(presentation.views.compact).toBe(
+      'Needs headless rendering: not enough content'
+    );
+  });
 });

--- a/tests/presentation/search-presentation.test.ts
+++ b/tests/presentation/search-presentation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { buildSearchPresentation } from '../../src/presentation/search-presentation.js';
+
+describe('buildSearchPresentation', () => {
+  it('builds compact, preview, and verbose search views', () => {
+    const presentation = buildSearchPresentation({
+      status: 'ok',
+      results: [
+        { title: 'Example One', url: 'https://example.com/one', snippet: 'First snippet' },
+        { title: 'Example Two', url: 'https://example.com/two', snippet: 'Second snippet' }
+      ],
+      metadata: { backend: 'duckduckgo', cacheHit: false }
+    });
+
+    expect(presentation.views.compact).toBe('Found 2 results');
+    expect(presentation.views.preview).toContain('1. Example One');
+    expect(presentation.views.verbose).toContain('First snippet');
+  });
+
+  it('builds concise error compact output', () => {
+    const presentation = buildSearchPresentation({
+      status: 'error',
+      results: [],
+      metadata: { backend: 'duckduckgo', cacheHit: false },
+      error: { code: 'NO_RESULTS', message: 'DuckDuckGo returned no usable results for this query.' }
+    });
+
+    expect(presentation.views.compact).toBe(
+      'Search failed: DuckDuckGo returned no usable results for this query.'
+    );
+  });
+});

--- a/tests/presentation/select-view.test.ts
+++ b/tests/presentation/select-view.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { selectPresentationView } from '../../src/presentation/select-view.js';
+
+describe('selectPresentationView', () => {
+  const envelope = {
+    mode: 'compact' as const,
+    views: {
+      compact: 'compact body',
+      preview: 'preview body',
+      verbose: 'verbose body'
+    }
+  };
+
+  it('returns compact only for compact mode', () => {
+    expect(selectPresentationView(envelope, 'compact')).toBe('compact body');
+  });
+
+  it('returns preview only for preview mode', () => {
+    expect(selectPresentationView(envelope, 'preview')).toBe('preview body');
+  });
+
+  it('falls back to compact when a richer view is missing', () => {
+    expect(
+      selectPresentationView({ mode: 'compact', views: { compact: 'compact only' } }, 'verbose')
+    ).toBe('compact only');
+  });
+});

--- a/tests/tools/web-explore.test.ts
+++ b/tests/tools/web-explore.test.ts
@@ -76,6 +76,13 @@ describe('web_explore tool', () => {
       }
     ]);
     expect(result.caveat).toBeUndefined();
+    expect(result.presentation?.views.compact).toBe(
+      'Reviewed 2 sources · synthesized answer with 2 findings'
+    );
+    expect(result.presentation?.views.preview).toContain(
+      'Use channel for branded Chrome or Edge when possible.'
+    );
+    expect(result).not.toHaveProperty('text');
   });
 
   it('returns a caveat when only partial evidence is available', async () => {
@@ -122,6 +129,9 @@ describe('web_explore tool', () => {
       }
     ]);
     expect(result.caveat).toBe('Evidence is partial, so this answer is based on the strongest source found so far.');
+    expect(result.presentation?.views.compact).toBe(
+      'Reviewed 1 sources · synthesized answer with 1 findings'
+    );
   });
 
   it('rejects empty exploration queries', async () => {
@@ -170,5 +180,6 @@ describe('web_explore tool', () => {
     expect(JSON.stringify(result)).not.toContain('lowValueOutcomes');
     expect(JSON.stringify(result)).not.toContain('suggestedHeadlessUrl');
     expect(result.findings).toEqual(['A concise summary.']);
+    expect(result.presentation?.views.preview).toContain('- A concise summary.');
   });
 });

--- a/tests/tools/web-fetch-headless.test.ts
+++ b/tests/tools/web-fetch-headless.test.ts
@@ -16,7 +16,12 @@ describe('web_fetch_headless tool', () => {
     expect(result).toMatchObject({
       status: 'ok',
       metadata: { method: 'headless', cacheHit: false, browser: 'chrome', navigationMs: 1200 },
-      content: { text: 'Rendered text' }
+      content: { text: 'Rendered text' },
+      presentation: {
+        views: {
+          compact: 'Fetched page · article extracted · 2 words'
+        }
+      }
     });
   });
 
@@ -30,7 +35,12 @@ describe('web_fetch_headless tool', () => {
 
     expect(result).toMatchObject({
       status: 'unsupported',
-      error: { code: 'UNSUPPORTED_URL' }
+      error: { code: 'UNSUPPORTED_URL' },
+      presentation: {
+        views: {
+          compact: 'Fetch failed: Only http and https URLs are supported.'
+        }
+      }
     });
   });
 });

--- a/tests/tools/web-fetch.test.ts
+++ b/tests/tools/web-fetch.test.ts
@@ -7,7 +7,12 @@ describe('web_fetch tool', () => {
 
     await expect(webFetch({ url: 'file:///tmp/test.html' })).resolves.toMatchObject({
       status: 'unsupported',
-      error: { code: 'UNSUPPORTED_URL' }
+      error: { code: 'UNSUPPORTED_URL' },
+      presentation: {
+        views: {
+          compact: 'Fetch failed: Only http and https URLs are supported.'
+        }
+      }
     });
   });
 
@@ -22,7 +27,12 @@ describe('web_fetch tool', () => {
     });
 
     await expect(webFetch({ url: 'https://example.com' })).resolves.toMatchObject({
-      status: 'needs_headless'
+      status: 'needs_headless',
+      presentation: {
+        views: {
+          compact: 'Fetch failed: not enough content'
+        }
+      }
     });
   });
 

--- a/tests/tools/web-fetch.test.ts
+++ b/tests/tools/web-fetch.test.ts
@@ -30,7 +30,7 @@ describe('web_fetch tool', () => {
       status: 'needs_headless',
       presentation: {
         views: {
-          compact: 'Fetch failed: not enough content'
+          compact: 'Needs headless rendering: not enough content'
         }
       }
     });

--- a/tests/tools/web-search.test.ts
+++ b/tests/tools/web-search.test.ts
@@ -12,10 +12,16 @@ describe('web_search tool', () => {
       `)
     });
 
-    await expect(search({ query: 'example' })).resolves.toEqual({
+    await expect(search({ query: 'example' })).resolves.toMatchObject({
       status: 'ok',
       results: [{ title: 'Example', url: 'https://example.com', snippet: 'Snippet' }],
-      metadata: { backend: 'duckduckgo', cacheHit: false }
+      metadata: { backend: 'duckduckgo', cacheHit: false },
+      presentation: {
+        views: {
+          compact: 'Found 1 result',
+          preview: '1. Example'
+        }
+      }
     });
   });
 


### PR DESCRIPTION
This makes the web tools much less noisy by default and finally gives the package a real user-facing config path instead of the old hidden config hook.

Added compact/preview/verbose presentation modes, file-backed global + project config, /web-agent settings with show/reset/mode helpers, and docs for the whole thing. Also fixed the scope-switching + sparse-save behavior so project/global settings don’t stomp on each other.

Fresh checks on this branch: npm test, npm run lint, npm run build, npm run docs:build, npm run eval:live. Changelog is prepped for a v0.3.0 release after merge.