### PR TITLE
release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is intentionally simple and release-oriented.
 ## Unreleased
 
 ### Added
+- Nothing yet.
+
+### Changed
+- Nothing yet.
+
+### Fixed
+- Nothing yet.
+
+### Breaking
+- None.
+
+## [0.3.0] - 2026-04-22
+### Added
 - Added compact, preview, and verbose presentation modes for web tool output.
 - Added a user-facing `/web-agent` settings UI plus helper commands for showing, resetting, and changing presentation config.
 - Added global and project-local presentation config files with project-overrides-global precedence.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@demigodmode/pi-web-agent",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@demigodmode/pi-web-agent",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demigodmode/pi-web-agent",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Pi package for reliable web access with explicit search, fetch, and headless boundaries.",
   "type": "module",
   "main": "./dist/extension.js",


### PR DESCRIPTION
Version bump and changelog cut for the presentation/settings release.

This moves main from 0.2.2 to 0.3.0 and records the shipped changes in CHANGELOG.md so the protected-branch workflow can stay intact. After this merges, we can push the v0.3.0 tag from updated main to exercise the npm publish flow.