### PR TITLE
Make web_explore the public research tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npm install --no-save @rollup/rollup-linux-x64-gnu
       - run: npm run lint
       - run: npm test
       - run: npm run build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,6 @@ jobs:
           cache: npm
       - uses: actions/configure-pages@v5
       - run: npm ci
-      - run: npm install --no-save @rollup/rollup-linux-x64-gnu
       - run: npm run docs:build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,6 @@ jobs:
       - run: node -v
       - run: npm -v
       - run: npm ci
-      - run: npm install --no-save @rollup/rollup-linux-x64-gnu
       - run: npm run lint
       - run: npm test
       - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ The format is intentionally simple and release-oriented.
 ### Changed
 - Simplified `/web-agent` presentation settings to `defaultMode` and `web_explore` only.
 - Updated live web evals to treat shell/network fallbacks after `web_explore` as a quality issue.
+- Updated the release script to use `npm version --no-git-tag-version` before tagging so package metadata is changed through npm instead of regex replacement.
 
 ### Fixed
 - Turned successful headless reads into usable `web_explore` evidence instead of returning empty results for dynamic docs pages.
 - Filtered headless bot-check/security-verification pages out of research evidence.
 - Made empty research results display as “No usable evidence found” instead of looking like a successful synthesis.
+- Added the Linux Rollup optional package to the lockfile so GitHub Actions can build from `npm ci` without patch-installing Rollup.
 
 ### Breaking
 - None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ The format is intentionally simple and release-oriented.
 ## Unreleased
 
 ### Added
-- Nothing yet.
+- Made `web_explore` the single public web research tool, with search, fetch, source ranking, and headless escalation handled internally.
+- Added adaptive research helpers for query planning, candidate selection, evidence ranking, stop decisions, and answer synthesis.
+- Added preview/verbose provenance for `web_explore` showing which internal reader produced each finding.
 
 ### Changed
-- Nothing yet.
+- Simplified `/web-agent` presentation settings to `defaultMode` and `web_explore` only.
+- Updated live web evals to treat shell/network fallbacks after `web_explore` as a quality issue.
 
 ### Fixed
-- Nothing yet.
+- Turned successful headless reads into usable `web_explore` evidence instead of returning empty results for dynamic docs pages.
+- Filtered headless bot-check/security-verification pages out of research evidence.
+- Made empty research results display as “No usable evidence found” instead of looking like a successful synthesis.
 
 ### Breaking
 - None.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,9 @@
 
 `@demigodmode/pi-web-agent` is a Pi package for web access.
 
-Most agent web tools blur search, fetch, browser rendering, and research into one vague thing. `pi-web-agent` keeps them separate, so transcripts stay cleaner and failures are easier to trust.
+Most agent web tools blur search, fetch, browser rendering, and research into one vague thing. `pi-web-agent` exposes one public research tool, `web_explore`, and keeps search/fetch/headless work inside that bounded workflow.
 
-The whole point is keeping the boundaries straight:
-
-- `web_search` is for discovery
-- `web_fetch` is for plain HTTP reads
-- `web_fetch_headless` is the explicit browser path
-- `web_explore` is the bounded research path
+The point is keeping the model-facing boundary simple: ask `web_explore` to research a question, and it handles discovery, HTTP reads, targeted browser rendering, source ranking, and caveats internally.
 
 That sounds obvious, but a lot of agent tooling gets fuzzy right there. This package is meant to be stricter about what it actually did and more willing to say when a read was not good enough to trust.
 
@@ -74,8 +69,8 @@ Helper commands:
 /web-agent reset project
 /web-agent reset global
 /web-agent mode preview
-/web-agent mode web_search verbose
-/web-agent mode web_search inherit
+/web-agent mode web_explore verbose
+/web-agent mode web_explore inherit
 ```
 
 Config files:
@@ -100,7 +95,6 @@ Example:
   "presentation": {
     "defaultMode": "compact",
     "tools": {
-      "web_search": { "mode": "preview" },
       "web_explore": { "mode": "verbose" }
     }
   }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,29 +2,40 @@
 
 The code is split into small modules on purpose.
 
-That is partly for code health, but mostly because this package gets worse fast if search, fetch, browser rendering, and research orchestration all blur together.
+That is partly for code health, but mostly because this package gets worse fast if search, fetch, browser rendering, and research synthesis all blur together.
 
 ## Main boundaries
 
-- `src/extension.ts` wires the package into Pi
-- `src/tools/` contains thin Pi-facing tool adapters
+- `src/extension.ts` wires the package into Pi and registers the public `web_explore` tool
+- `src/tools/` contains tool adapters and internal tool-shaped helpers
 - `src/search/` holds search backend logic
 - `src/fetch/` handles HTTP and headless fetch logic
 - `src/extract/` handles readable-content extraction
-- `src/orchestration/` handles bounded research flow
+- `src/orchestration/` handles the bounded research flow
 - `src/cache/` holds small cache helpers
 - `src/types.ts` defines shared contracts
 
+## Public surface vs internals
+
+The public model-facing web research surface is `web_explore`.
+
+The lower-level capabilities still exist in code, but they are internal steps now:
+
+- search is for discovery
+- HTTP fetch is for plain page reads
+- headless fetch is for selected browser-rendered reads
+- orchestration decides when enough evidence exists
+
+Keeping those responsibilities separate still matters. It lets the package show provenance like `[web_fetch]` or `[web_fetch_headless]` in preview/verbose output without forcing the outer model to manually chain those steps.
+
 ## Why the split exists
 
-`web_search` should stay about discovery.
+A search result should not be treated as a page read.
 
-`web_fetch` should stay about plain HTTP reads.
+A weak HTTP extraction should not be treated as reliable evidence.
 
-`web_fetch_headless` should stay explicit.
+A bot-check page should not become a source.
 
-`web_explore` should stay the higher-level research path.
+And if more evidence is needed, the model should call `web_explore` again with a narrower query instead of dropping into shell commands or raw HTTP calls.
 
-Once those responsibilities start leaking into each other, the package becomes harder to reason about and easier to lie with by accident.
-
-Keeping the boundaries explicit makes failures easier to understand and makes it easier to change one part without quietly changing the meaning of another.
+Those boundaries make failures easier to understand and make it harder for the package to lie by accident.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,52 +12,29 @@ If Pi is already running, reload or restart it so the package gets picked up.
 
 ## What you get
 
-The package exposes four tools:
+The package exposes one public web research tool:
 
-- `web_search`
-- `web_fetch`
-- `web_fetch_headless`
 - `web_explore`
 
-The important part is that they do different jobs on purpose.
+Use it when you want Pi to find and compare current web sources.
 
-`web_search` finds sources.
+`web_explore` handles the annoying parts internally: search, HTTP reads, targeted headless rendering, source ranking, and caveats when the evidence is not strong enough.
 
-`web_fetch` tries to read one page over plain HTTP.
-
-`web_fetch_headless` is there for pages that really do need a browser.
-
-`web_explore` is the higher-level research path when the job is bigger than one search or one page read.
-
-## Try a few prompts
-
-### Search for sources
-
-> Search for recent docs about Playwright browser installation.
-
-That should push Pi toward `web_search` when the job is discovery.
-
-### Read one page directly
-
-> Fetch and summarize https://example.com/article
-
-That should favor `web_fetch` when the job is reading a specific page over HTTP.
-
-### Use the browser path explicitly
-
-> Use headless fetch to read https://example.com/app
-
-That should favor `web_fetch_headless` when browser rendering is actually the point.
-
-### Let the package do bounded research
+## Try a prompt
 
 > Find current docs and discussions about configuring Vitest coverage in TypeScript projects.
 
-That should favor `web_explore` for the broader research workflow.
+Pi should call `web_explore` and return a compact research result. If you need more detail inline, switch presentation mode to `preview` or `verbose`.
+
+Another example:
+
+> Find two or three current sources on DuckDuckGo HTML scraping in Node.js and tell me what the common parsing pitfalls are.
+
+That should still go through `web_explore`. If the first pass is thin, Pi can call `web_explore` again with a narrower query instead of dropping into shell commands or raw HTTP calls.
 
 ## Presentation defaults
 
-The package renders web tool output in `compact` mode by default.
+The package renders web research output in `compact` mode by default.
 
 If you want to change that, open the settings UI with:
 
@@ -65,10 +42,10 @@ If you want to change that, open the settings UI with:
 /web-agent
 ```
 
-That lets you change the default mode and per-tool overrides without editing code.
+That lets you change the default presentation mode and the `web_explore` override without editing JSON by hand.
 
 If you want the full details, see [Presentation and settings](/presentation).
 
 ## One thing to keep in mind
 
-If the package says a page was too weak to trust over HTTP, that is not it being stubborn. That is the whole point of the contract.
+If the package says no usable evidence was found, or adds a caveat, that is intentional. It is better to admit the research pass was thin than to turn weak pages or bot-check screens into fake confidence.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,25 +1,25 @@
 # pi-web-agent
 
-`@demigodmode/pi-web-agent` is a Pi package for web access that tries to stay honest about what it actually did.
+`@demigodmode/pi-web-agent` is a Pi package for web research.
 
-Most agent web tools blur search, fetch, browser rendering, and research into one vague thing. `pi-web-agent` keeps them separate, so transcripts stay cleaner and failures are easier to trust.
+Most agent web tooling turns search, fetch, browser rendering, and synthesis into one blurry thing. This package keeps the model-facing surface simple instead: use `web_explore` for web research, and let it handle the lower-level work internally.
 
-The whole project is built around a simple rule: searching for a page is not the same thing as reading it, and reading it over plain HTTP is not the same thing as rendering it in a browser.
-
-That sounds obvious, but agent web tooling gets fuzzy right there all the time. Search snippets get treated like page reads. Browser fallback happens quietly. Thin or blocked reads get softened into fake confidence.
-
-This package is trying to do the opposite.
+That lower-level work still matters. A search result is not the same as a page read. A plain HTTP read is not the same as rendering a page in a browser. But those are implementation details now, not separate tools the model has to juggle in normal use.
 
 ## The contract
 
-- `web_search` is for discovery
-- `web_fetch` is for plain HTTP reads
-- `web_fetch_headless` is the explicit browser path
-- `web_explore` is the bounded research path
+`web_explore` is the public research entrypoint.
 
-Those boundaries are the point.
+Internally it can:
 
-They make failures easier to reason about, and they make it harder for the tooling to quietly do something different from what you asked for.
+- search for candidate sources
+- fetch pages over HTTP
+- escalate selected pages to headless rendering
+- rank official sources above weaker sources
+- include community sources as practical context
+- stop with a caveat when the evidence is thin
+
+In `preview` or `verbose` mode, you can still see which internal reader produced each finding, for example `[web_fetch]` or `[web_fetch_headless]`. That gives you transparency without exposing a bunch of low-level public tools.
 
 ## What you get right now
 
@@ -27,11 +27,11 @@ This project is still early, but it is usable.
 
 Right now it gives you:
 
-- search results that stay search results
-- plain HTTP fetch that can say "this isn't reliable enough"
-- explicit headless fetch when a browser is actually needed
-- a higher-level research tool that is meant to stop after a bounded pass instead of wandering forever
-- compact-by-default transcript output with user-facing presentation settings
+- one public web research tool: `web_explore`
+- compact-by-default transcript output
+- preview/verbose modes that show internal research provenance
+- a `/web-agent` settings UI for presentation config
+- bounded research behavior that is willing to say when evidence was weak
 
 ## Start here
 

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -1,8 +1,8 @@
 # Presentation and settings
 
-`pi-web-agent` keeps web tool output compact by default.
+`pi-web-agent` keeps web research output compact by default.
 
-That is deliberate. Search results, fetches, and research summaries can get noisy fast, especially when the package is doing exactly what you asked and returning a lot of useful detail. The goal here is to keep the transcript readable first, while still letting you ask for more when you want it.
+That is deliberate. Research output gets noisy fast, especially when a tool is doing multiple search and fetch passes internally. The goal is to keep the transcript readable first, while still letting you ask for more detail when you want it.
 
 ## Before and after
 
@@ -23,26 +23,44 @@ If you want more detail inline, switch modes in `/web-agent` settings instead of
 
 ## The three presentation modes
 
-Every web tool result is shaped into one visible mode at a time:
+`web_explore` can be shown in one visible mode at a time:
 
 - `compact` — the shortest useful summary
-- `preview` — a little more context, still bounded
-- `verbose` — the fullest bounded view
+- `preview` — findings with internal provenance
+- `verbose` — findings, sources, caveats, and internal provenance
 
 The important part is that these are not stacked on top of each other.
 
-If a tool result is shown in `preview`, you get the preview body instead of a compact summary plus extra text under it.
+If a result is shown in `preview`, you get the preview body instead of a compact summary plus extra text under it.
 
 ## Default behavior
 
-Out of the box, all tools use `compact`:
+Out of the box, `web_explore` uses `compact`.
 
-- `web_search`
-- `web_fetch`
-- `web_fetch_headless`
-- `web_explore`
+Example compact output:
 
-That keeps normal usage calm instead of turning every search or fetch into a transcript dump.
+```text
+Reviewed 3 sources · synthesized answer with 3 findings
+```
+
+If no useful evidence was found, compact output says that plainly:
+
+```text
+No usable evidence found
+```
+
+## Preview and verbose provenance
+
+Preview and verbose modes show the internal reader that produced each finding:
+
+```text
+- [web_fetch] Official docs say ...
+- [web_fetch_headless] Rendered page says ...
+
+Internal research: web_search ×2, web_fetch ×5, web_fetch_headless ×1
+```
+
+Those labels are internal provenance. They do not mean `web_search`, `web_fetch`, or `web_fetch_headless` are public tools in normal use.
 
 ## The fastest way to change it
 
@@ -66,8 +84,8 @@ These also work:
 /web-agent reset project
 /web-agent reset global
 /web-agent mode preview
-/web-agent mode web_search verbose
-/web-agent mode web_search inherit
+/web-agent mode web_explore verbose
+/web-agent mode web_explore inherit
 ```
 
 ## What `/web-agent` does
@@ -78,7 +96,7 @@ From there you can:
 
 - choose whether you are editing global or project settings
 - change the default mode
-- change per-tool overrides
+- change the `web_explore` override
 - save, reset the current scope, or cancel
 
 Keyboard shortcuts in the settings UI:
@@ -117,16 +135,11 @@ That means you can keep a personal default and then override it inside one repo 
 
 ## How inheritance works
 
-Per-tool overrides inherit from the current default mode unless you set them explicitly.
+The `web_explore` override inherits from the current default mode unless you set it explicitly.
 
-So if your default mode is `preview` and only `web_explore` is set to `verbose`, then:
+So if your default mode is `preview` and `web_explore` is set to `verbose`, then `web_explore` uses `verbose`.
 
-- `web_search` uses `preview`
-- `web_fetch` uses `preview`
-- `web_fetch_headless` uses `preview`
-- `web_explore` uses `verbose`
-
-When you switch a tool back to `inherit`, the package removes that override instead of writing extra noise into the config file.
+When you switch `web_explore` back to `inherit`, the package removes that override instead of writing extra noise into the config file.
 
 ## Example config
 
@@ -135,7 +148,6 @@ When you switch a tool back to `inherit`, the package removes that override inst
   "presentation": {
     "defaultMode": "compact",
     "tools": {
-      "web_search": { "mode": "preview" },
       "web_explore": { "mode": "verbose" }
     }
   }
@@ -147,7 +159,7 @@ When you switch a tool back to `inherit`, the package removes that override inst
 A good practical rule:
 
 - use `compact` if you mostly want clean transcripts
-- use `preview` if you want a little more inline context for discovery and fetches
-- use `verbose` if you are actively inspecting tool output and do not mind a larger transcript
+- use `preview` if you want findings plus internal provenance
+- use `verbose` if you want sources and caveats inline too
 
-For most people, `compact` as the default plus a couple of per-tool overrides is probably the sweet spot.
+For most people, `compact` as the default is probably right. Use `preview` or `verbose` when you are debugging research behavior or want to inspect what happened under the hood.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,67 +1,62 @@
 # Tools
 
-The package works because the tools do not all pretend to do the same job.
-
-That might sound small, but it is most of the reason this package exists.
-
-## `web_search`
-
-Use it when you want discovery:
-
-- links
-- titles
-- snippets
-- a first pass at what sources exist
-
-What it should not do is imply that a page was actually read.
-
-If all you have is search output, then all you have is search output.
-
-## `web_fetch`
-
-Use it when you want to read one page over plain HTTP.
-
-This is the direct path for straightforward page reads.
-
-What it should not do is quietly switch into browser mode just because the target page is awkward.
-
-If the page looks too thin, too blocked, or too JS-heavy to trust, it should return `needs_headless` instead of bluffing.
-
-That is a feature, not a failure.
-
-## `web_fetch_headless`
-
-Use it when browser rendering is explicitly needed.
-
-That might be because the page is client-rendered, because the plain HTTP result was too weak, or because you already know the target is browser-first.
-
-What it should not do is act like a hidden fallback behind normal HTTP fetches.
-
-If a browser gets launched, it should be because you asked for the browser path.
+The public tool surface is intentionally small now.
 
 ## `web_explore`
 
-Use it for broader web research where the job is to gather and compare sources with a bounded search and fetch pass.
+Use `web_explore` for web research questions:
 
-This is the higher-level path when you are asking a research question, not just requesting one search or one page read.
+- current docs lookups
+- comparing sources
+- checking discussions or issues
+- getting a recommendation with citations
+- finding practical context around a library or API
 
-What it should not do is turn into endless low-level tool churn after a decent answer already exists.
+It runs a bounded research workflow instead of making the model manually chain separate search/fetch/browser tools.
 
-That tighter behavior is intentional.
+Internally, `web_explore` can do a few things:
 
-## Presentation and transcript output
+- plan search queries
+- run web search
+- pick candidate pages
+- read pages over HTTP
+- escalate selected pages to headless rendering
+- rank evidence
+- synthesize findings and caveats
 
-These tools now render in a compact transcript-friendly form by default.
+The important bit: those internal steps are not separate public tools for normal model use. If more web evidence is needed, the model should call `web_explore` again with a narrower query.
 
-That means using a tool does not automatically dump its fullest possible body inline. If you want richer output, change the package settings instead of expecting the transcript to always show the maximum amount of detail.
+## What preview and verbose show
 
-See [Presentation and settings](/presentation) for the config UI, JSON paths, and mode behavior.
+In compact mode, `web_explore` keeps the transcript short:
 
-## Which one should you reach for?
+```text
+Reviewed 3 sources · synthesized answer with 3 findings
+```
 
-A quick rule of thumb:
+In preview or verbose mode, findings include where the evidence came from internally:
 
-- if you want links and snippets, use `web_search`
-- if you want one page over HTTP, use `web_fetch`
-- if you want a browser-rendered page, use `web_fetch_headless`
-- if you want a bounded research workflow, use `web_explore`
+```text
+- [web_fetch] Official docs say ...
+- [web_fetch_headless] Rendered docs show ...
+
+Internal research: web_search ×2, web_fetch ×5, web_fetch_headless ×1
+```
+
+That is meant to be transparent, not an invitation to call those internal steps directly.
+
+## When evidence is weak
+
+Sometimes a research pass finds nothing useful. In that case the output says:
+
+```text
+No usable evidence found.
+```
+
+That is expected. Web pages can be thin, blocked, duplicated, or irrelevant. A follow-up `web_explore` call with a more specific query is usually the right next move.
+
+## A practical rule
+
+If the task is web research, use `web_explore`.
+
+If you need another angle, call `web_explore` again with a better query. Do not switch to shell network commands like `curl`, `Invoke-WebRequest`, or `npm view` just to continue web research.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,12 +1,28 @@
 # Troubleshooting
 
-## `web_fetch` returned `needs_headless`
+## `web_explore` found no usable evidence
 
-That usually means the plain HTTP read was not strong enough to trust.
+That means the research pass ran, but none of the fetched pages produced evidence worth showing.
 
-This is not the package refusing to work. It is the package refusing to pretend a weak read was good enough.
+That can happen when:
 
-If the page is heavily client-rendered or the extracted content is too thin, `web_fetch_headless` is probably the better next step.
+- search results were off-topic
+- pages were blocked or mostly boilerplate
+- the readable content was too thin
+- headless rendering hit a bot-check page
+- several results were duplicates or low-value package pages
+
+A good next move is another `web_explore` call with a narrower query. For example, include the library name, docs site, issue tracker, or exact API you care about.
+
+## The output has `[web_fetch]` or `[web_fetch_headless]` labels
+
+Those labels show internal provenance.
+
+- `[web_fetch]` means the finding came from a plain HTTP read.
+- `[web_fetch_headless]` means it came from a browser-rendered read.
+- `[web_explore]` is a fallback label when older or hand-shaped data did not include a reader method.
+
+They are there so preview/verbose mode stays honest about what happened under the hood.
 
 ## The page looked thin or partial
 
@@ -16,7 +32,7 @@ That can happen when:
 - the readable content is blocked or minimal over HTTP
 - the page shell is easier to fetch than the real content
 
-Again, this is exactly where a clean `needs_headless` result is more useful than fake certainty.
+`web_explore` can escalate selected pages to headless rendering internally, but that still does not guarantee a clean result. Some sites render bot checks, cookie walls, or noisy app shells even in a browser.
 
 ## `/web-agent` did something unexpected
 
@@ -35,6 +51,13 @@ If the current behavior does not match what you expected, check both config scop
 
 Project config overrides global config.
 
+The settings UI currently exposes:
+
+- `defaultMode`
+- `web_explore`
+
+Older config files may still contain keys for older low-level tools. They are ignored by the current UI.
+
 ## Pi seems to be loading the wrong copy
 
 If you use both the published package and the local repo-based extension, double-check which one Pi actually loaded.
@@ -43,14 +66,10 @@ This is an easy way to waste time debugging the wrong thing.
 
 A quick sanity check is to make a tiny local change, reload Pi, and see whether the behavior changes with it.
 
-## A search result was not the same as a page read
+## The model used shell commands for web research
 
-That is intentional.
+That is not the intended path.
 
-`web_search` is discovery only. If you want page content, use `web_fetch` or `web_fetch_headless`.
+For web research, the model should use `web_explore`. If the first result is thin, it should call `web_explore` again with a narrower query rather than using shell network commands like `curl`, `Invoke-WebRequest`, or `npm view`.
 
-## Headless fetch did not help as much as expected
-
-Sometimes the browser path gets you a better page, and sometimes it mostly gets you a better shell with a lot of noise around it.
-
-Busy homepages and app-like sites can still be messy even after rendering. The goal is better signal, not miracles.
+The live eval tracks this as a quality issue because shell networking bypasses the package's source ranking, provenance, and caveat behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6827,6 +6827,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     }
   }
 }

--- a/scripts/live-web-eval.ts
+++ b/scripts/live-web-eval.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import {
   AuthStorage,
   createAgentSession,
@@ -51,6 +52,7 @@ type PromptMetrics = {
   webExploreFirstWebTool: boolean;
   totalToolCalls: number;
   totalWebToolCalls: number;
+  networkShellFallbacksAfterExplore: number;
 };
 
 type PromptEvaluation = {
@@ -198,7 +200,14 @@ function extractText(value: unknown): string {
   return '';
 }
 
-function buildMetrics(toolCalls: ToolCallRecord[]): PromptMetrics {
+function isNetworkShellCommand(command: unknown): boolean {
+  if (typeof command !== 'string') return false;
+  return /\b(Invoke-WebRequest|Invoke-RestMethod|curl(?:\.exe)?|wget|npm\s+(?:view|search|pack)|pip\s+index)\b|https?:\/\//i.test(
+    command
+  );
+}
+
+export function buildMetrics(toolCalls: ToolCallRecord[]): PromptMetrics {
   const webToolNames = new Set(['web_explore', 'web_search', 'web_fetch', 'web_fetch_headless']);
   const webToolCalls = toolCalls.filter((call) => webToolNames.has(call.toolName));
   const firstWebTool = webToolCalls[0];
@@ -208,11 +217,17 @@ function buildMetrics(toolCalls: ToolCallRecord[]): PromptMetrics {
     webExploreUsed: firstWebExploreIndex !== -1,
     webExploreFirstWebTool: firstWebTool?.toolName === 'web_explore',
     totalToolCalls: toolCalls.length,
-    totalWebToolCalls: webToolCalls.length
+    totalWebToolCalls: webToolCalls.length,
+    networkShellFallbacksAfterExplore:
+      firstWebExploreIndex === -1
+        ? 0
+        : toolCalls
+            .slice(firstWebExploreIndex + 1)
+            .filter((call) => call.toolName === 'bash' && isNetworkShellCommand((call.args as { command?: unknown })?.command)).length
   };
 }
 
-function evaluateVerdict(metrics: PromptMetrics, finalAnswer: string): {
+export function evaluateVerdict(metrics: PromptMetrics, finalAnswer: string): {
   verdict: 'pass' | 'mixed' | 'fail';
   notes: string[];
 } {
@@ -227,12 +242,16 @@ function evaluateVerdict(metrics: PromptMetrics, finalAnswer: string): {
     notes.push('web_explore was not the first web research tool');
   }
 
+  if (metrics.networkShellFallbacksAfterExplore > 0) {
+    notes.push(`network-capable shell fallback after web_explore (${metrics.networkShellFallbacksAfterExplore})`);
+  }
+
   if (!finalAnswer.trim()) {
     notes.push('final answer text was empty');
     return { verdict: 'fail', notes };
   }
 
-  if (metrics.webExploreFirstWebTool) {
+  if (metrics.webExploreFirstWebTool && notes.length === 0) {
     return { verdict: 'pass', notes };
   }
 
@@ -278,6 +297,7 @@ function formatMarkdown(run: EvaluationRun): string {
         `- web_explore first web tool: ${prompt.metrics.webExploreFirstWebTool}\n` +
         `- total tool calls: ${prompt.metrics.totalToolCalls}\n` +
         `- total web tool calls: ${prompt.metrics.totalWebToolCalls}\n` +
+        `- network shell fallbacks after web_explore: ${prompt.metrics.networkShellFallbacksAfterExplore}\n` +
 
         `Tool order:\n${tools || '  none'}\n\n` +
         `Notes:\n${notes}\n\n` +
@@ -455,6 +475,7 @@ async function main() {
     console.log(`  web_explore used: ${prompt.metrics.webExploreUsed}`);
     console.log(`  web_explore first web tool: ${prompt.metrics.webExploreFirstWebTool}`);
     console.log(`  total web tool calls: ${prompt.metrics.totalWebToolCalls}`);
+    console.log(`  network shell fallbacks after web_explore: ${prompt.metrics.networkShellFallbacksAfterExplore}`);
   }
 
   for (const testCase of run.searchFailureCases) {
@@ -464,4 +485,6 @@ async function main() {
   }
 }
 
-await main();
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  await main();
+}

--- a/scripts/live-web-eval.ts
+++ b/scripts/live-web-eval.ts
@@ -51,14 +51,6 @@ type PromptMetrics = {
   webExploreFirstWebTool: boolean;
   totalToolCalls: number;
   totalWebToolCalls: number;
-  searchCalls: number;
-  fetchCalls: number;
-  headlessCalls: number;
-  lowLevelCallsAfterExplore: number;
-  guardedLowLevelCallsAfterExplore: number;
-  emptySearches: number;
-  unsupportedFetches: number;
-  botCheckHeadlesses: number;
 };
 
 type PromptEvaluation = {
@@ -206,50 +198,8 @@ function extractText(value: unknown): string {
   return '';
 }
 
-function toolDetails(result: unknown): unknown {
-  if (!result || typeof result !== 'object') return result;
-  const record = result as Record<string, unknown>;
-  return record.details ?? result;
-}
-
-function isEmptySearchResult(result: unknown): boolean {
-  const details = toolDetails(result);
-  if (!details || typeof details !== 'object') return false;
-  const record = details as Record<string, unknown>;
-  return record.status === 'ok' && Array.isArray(record.results) && record.results.length === 0;
-}
-
-function isUnsupportedFetchResult(result: unknown): boolean {
-  const details = toolDetails(result);
-  return !!details && typeof details === 'object' && (details as Record<string, unknown>).status === 'unsupported';
-}
-
-function isBotCheckHeadlessResult(result: unknown): boolean {
-  const details = toolDetails(result);
-  if (!details || typeof details !== 'object') return false;
-  const record = details as Record<string, unknown>;
-  const content = record.content;
-  const text = extractText(content);
-  const title =
-    content && typeof content === 'object' && !Array.isArray(content)
-      ? String((content as Record<string, unknown>).title ?? '')
-      : '';
-
-  return /just a moment|security verification|verify you are not a bot/i.test(`${title}\n${text}`);
-}
-
-function isPostWebExploreGuardResult(result: unknown): boolean {
-  const details = toolDetails(result);
-  if (!details || typeof details !== 'object') return false;
-  const record = details as Record<string, unknown>;
-  const error = record.error;
-  if (!error || typeof error !== 'object') return false;
-  return (error as Record<string, unknown>).code === 'POST_WEB_EXPLORE_GUARD';
-}
-
 function buildMetrics(toolCalls: ToolCallRecord[]): PromptMetrics {
   const webToolNames = new Set(['web_explore', 'web_search', 'web_fetch', 'web_fetch_headless']);
-  const lowLevelWebToolNames = new Set(['web_search', 'web_fetch', 'web_fetch_headless']);
   const webToolCalls = toolCalls.filter((call) => webToolNames.has(call.toolName));
   const firstWebTool = webToolCalls[0];
   const firstWebExploreIndex = toolCalls.findIndex((call) => call.toolName === 'web_explore');
@@ -258,39 +208,7 @@ function buildMetrics(toolCalls: ToolCallRecord[]): PromptMetrics {
     webExploreUsed: firstWebExploreIndex !== -1,
     webExploreFirstWebTool: firstWebTool?.toolName === 'web_explore',
     totalToolCalls: toolCalls.length,
-    totalWebToolCalls: webToolCalls.length,
-    searchCalls: toolCalls.filter((call) => call.toolName === 'web_search').length,
-    fetchCalls: toolCalls.filter((call) => call.toolName === 'web_fetch').length,
-    headlessCalls: toolCalls.filter((call) => call.toolName === 'web_fetch_headless').length,
-    lowLevelCallsAfterExplore:
-      firstWebExploreIndex === -1
-        ? toolCalls.filter(
-            (call) => lowLevelWebToolNames.has(call.toolName) && !isPostWebExploreGuardResult(call.result)
-          ).length
-        : toolCalls
-            .slice(firstWebExploreIndex + 1)
-            .filter(
-              (call) => lowLevelWebToolNames.has(call.toolName) && !isPostWebExploreGuardResult(call.result)
-            ).length,
-    guardedLowLevelCallsAfterExplore:
-      firstWebExploreIndex === -1
-        ? toolCalls.filter(
-            (call) => lowLevelWebToolNames.has(call.toolName) && isPostWebExploreGuardResult(call.result)
-          ).length
-        : toolCalls
-            .slice(firstWebExploreIndex + 1)
-            .filter(
-              (call) => lowLevelWebToolNames.has(call.toolName) && isPostWebExploreGuardResult(call.result)
-            ).length,
-    emptySearches: toolCalls.filter((call) => call.toolName === 'web_search' && isEmptySearchResult(call.result)).length,
-    unsupportedFetches: toolCalls.filter(
-      (call) =>
-        (call.toolName === 'web_fetch' || call.toolName === 'web_fetch_headless') &&
-        isUnsupportedFetchResult(call.result)
-    ).length,
-    botCheckHeadlesses: toolCalls.filter(
-      (call) => call.toolName === 'web_fetch_headless' && isBotCheckHeadlessResult(call.result)
-    ).length
+    totalWebToolCalls: webToolCalls.length
   };
 }
 
@@ -309,30 +227,12 @@ function evaluateVerdict(metrics: PromptMetrics, finalAnswer: string): {
     notes.push('web_explore was not the first web research tool');
   }
 
-  if (metrics.lowLevelCallsAfterExplore > 2) {
-    notes.push(`too many low-level calls after web_explore (${metrics.lowLevelCallsAfterExplore})`);
-  }
-
-  if (metrics.emptySearches > 0) {
-    notes.push(`empty web_search calls observed (${metrics.emptySearches})`);
-  }
-
-  if (metrics.botCheckHeadlesses > 0) {
-    notes.push(`headless bot-check pages observed (${metrics.botCheckHeadlesses})`);
-  }
-
   if (!finalAnswer.trim()) {
     notes.push('final answer text was empty');
     return { verdict: 'fail', notes };
   }
 
-  const looksClean =
-    metrics.webExploreFirstWebTool &&
-    metrics.lowLevelCallsAfterExplore <= 1 &&
-    metrics.emptySearches === 0 &&
-    metrics.botCheckHeadlesses === 0;
-
-  if (looksClean) {
+  if (metrics.webExploreFirstWebTool) {
     return { verdict: 'pass', notes };
   }
 
@@ -378,14 +278,7 @@ function formatMarkdown(run: EvaluationRun): string {
         `- web_explore first web tool: ${prompt.metrics.webExploreFirstWebTool}\n` +
         `- total tool calls: ${prompt.metrics.totalToolCalls}\n` +
         `- total web tool calls: ${prompt.metrics.totalWebToolCalls}\n` +
-        `- web_search calls: ${prompt.metrics.searchCalls}\n` +
-        `- web_fetch calls: ${prompt.metrics.fetchCalls}\n` +
-        `- web_fetch_headless calls: ${prompt.metrics.headlessCalls}\n` +
-        `- low-level calls after web_explore: ${prompt.metrics.lowLevelCallsAfterExplore}\n` +
-        `- guarded low-level calls after web_explore: ${prompt.metrics.guardedLowLevelCallsAfterExplore}\n` +
-        `- empty searches: ${prompt.metrics.emptySearches}\n` +
-        `- unsupported fetches: ${prompt.metrics.unsupportedFetches}\n` +
-        `- bot-check headlesses: ${prompt.metrics.botCheckHeadlesses}\n\n` +
+
         `Tool order:\n${tools || '  none'}\n\n` +
         `Notes:\n${notes}\n\n` +
         `Final answer:\n\n${prompt.finalAnswer.trim() || '(empty)'}\n`;
@@ -559,11 +452,9 @@ async function main() {
 
   for (const prompt of run.prompts) {
     console.log(`\n${prompt.id} -> ${prompt.verdict}`);
+    console.log(`  web_explore used: ${prompt.metrics.webExploreUsed}`);
     console.log(`  web_explore first web tool: ${prompt.metrics.webExploreFirstWebTool}`);
-    console.log(`  low-level calls after web_explore: ${prompt.metrics.lowLevelCallsAfterExplore}`);
-    console.log(`  guarded low-level calls after web_explore: ${prompt.metrics.guardedLowLevelCallsAfterExplore}`);
-    console.log(`  empty searches: ${prompt.metrics.emptySearches}`);
-    console.log(`  bot-check headlesses: ${prompt.metrics.botCheckHeadlesses}`);
+    console.log(`  total web tool calls: ${prompt.metrics.totalWebToolCalls}`);
   }
 
   for (const testCase of run.searchFailureCases) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -69,13 +69,6 @@ function rewriteChangelog(changelog, nextVersion) {
   );
 }
 
-function rewritePackageVersion(packageJsonText, nextVersion) {
-  return packageJsonText.replace(
-    /"version":\s*"[^"]+"/,
-    `"version": "${nextVersion}"`
-  );
-}
-
 export function rewritePackageLockVersion(packageLockText, nextVersion) {
   const packageLock = JSON.parse(packageLockText);
   packageLock.version = nextVersion;
@@ -95,7 +88,6 @@ function main() {
 
   const changelog = readFileSync(changelogPath, 'utf8');
   const packageJsonText = readFileSync(packageJsonPath, 'utf8');
-  const packageLockText = readFileSync(packageLockPath, 'utf8');
   const packageJson = JSON.parse(packageJsonText);
 
   const unreleased = parseUnreleasedSections(changelog);
@@ -121,8 +113,8 @@ function main() {
 
   ensureCleanWorkingTree();
 
-  writeFileSync(packageJsonPath, rewritePackageVersion(packageJsonText, nextVersion));
-  writeFileSync(packageLockPath, rewritePackageLockVersion(packageLockText, nextVersion));
+  execSync(`npm version ${nextVersion} --no-git-tag-version`, { stdio: 'inherit' });
+  execSync('npm install --package-lock-only --include=optional', { stdio: 'inherit' });
   writeFileSync(changelogPath, rewriteChangelog(changelog, nextVersion));
 
   execSync(`git add ${packageJsonPath} ${packageLockPath} ${changelogPath}`, { stdio: 'inherit' });

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -38,12 +38,7 @@ export type SettingsDraftState = {
   config: PresentationConfig;
 };
 
-const PRESENTATION_TOOL_NAMES: PresentationToolName[] = [
-  'web_search',
-  'web_fetch',
-  'web_fetch_headless',
-  'web_explore'
-];
+const PRESENTATION_TOOL_NAMES: PresentationToolName[] = ['web_explore'];
 
 function parseScopeToken(token: string | undefined): PresentationScope | undefined {
   return token === 'global' || token === 'project' ? token : undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,9 @@ async function renderToolText(
 export default function extension(pi: ExtensionAPI) {
   registerWebAgentConfigCommands(pi);
 
-  const webExplore = createWebExploreTool();
+  const webExplore =
+    (pi as ExtensionAPI & { __webExploreTool?: ReturnType<typeof createWebExploreTool> }).__webExploreTool ??
+    createWebExploreTool();
 
   pi.on('before_agent_start', async (event) => ({
     systemPrompt:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,15 +10,7 @@ import type {
   PresentationToolName
 } from './presentation/types.js';
 import { createWebExploreTool } from './tools/web-explore.js';
-import { createWebFetchTool } from './tools/web-fetch.js';
-import { createWebFetchHeadlessTool } from './tools/web-fetch-headless.js';
-import { createWebSearchTool } from './tools/web-search.js';
-import type {
-  WebExploreResponse,
-  WebFetchHeadlessResponse,
-  WebFetchResponse,
-  WebSearchResponse
-} from './types.js';
+import type { WebExploreResponse } from './types.js';
 
 type ToolResultWithPresentation = {
   presentation?: PresentationEnvelope;
@@ -54,187 +46,25 @@ async function renderToolText(
 export default function extension(pi: ExtensionAPI) {
   registerWebAgentConfigCommands(pi);
 
-  const webSearch = createWebSearchTool();
-  const webFetch = createWebFetchTool();
-  const webFetchHeadless = createWebFetchHeadlessTool();
   const webExplore = createWebExploreTool();
-  let webExploreUsedInCurrentFlow = false;
-  const postWebExploreGuardError = {
-    code: 'POST_WEB_EXPLORE_GUARD',
-    message:
-      'web_explore already ran for this research task. Only use low-level web tools if there is a specific unresolved gap.'
-  };
 
-  async function guardSearchResponse() {
-    const result: WebSearchResponse = {
-      status: 'error',
-      results: [],
-      metadata: {
-        backend: 'duckduckgo',
-        cacheHit: false
-      },
-      error: postWebExploreGuardError,
-      presentation: {
-        mode: 'compact',
-        views: {
-          compact: `Search failed: ${postWebExploreGuardError.message}`
-        }
-      }
-    };
-
-    return {
-      content: [{ type: 'text' as const, text: await renderToolText(pi, 'web_search', result) }],
-      details: result,
-      isError: true as const
-    };
-  }
-
-  async function guardFetchResponse(url: string) {
-    const result: WebFetchResponse = {
-      status: 'error',
-      url,
-      metadata: {
-        method: 'http',
-        cacheHit: false
-      },
-      error: postWebExploreGuardError,
-      presentation: {
-        mode: 'compact',
-        views: {
-          compact: `Fetch failed: ${postWebExploreGuardError.message}`
-        }
-      }
-    };
-
-    return {
-      content: [{ type: 'text' as const, text: await renderToolText(pi, 'web_fetch', result) }],
-      details: result,
-      isError: true as const
-    };
-  }
-
-  async function guardHeadlessResponse(url: string) {
-    const result: WebFetchHeadlessResponse = {
-      status: 'error',
-      url,
-      metadata: {
-        method: 'headless',
-        cacheHit: false
-      },
-      error: postWebExploreGuardError,
-      presentation: {
-        mode: 'compact',
-        views: {
-          compact: `Fetch failed: ${postWebExploreGuardError.message}`
-        }
-      }
-    };
-
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: await renderToolText(pi, 'web_fetch_headless', result)
-        }
-      ],
-      details: result,
-      isError: true as const
-    };
-  }
-
-  pi.on('before_agent_start', async (event) => {
-    webExploreUsedInCurrentFlow = false;
-
-    return {
-      systemPrompt:
-        `${event.systemPrompt}\n\n` +
-        'For web research questions that require finding and comparing multiple sources, prefer web_explore. ' +
-        'Use web_search, web_fetch, and web_fetch_headless for direct/manual operations like explicit search calls, specific URL reads, or debugging. ' +
-        'After using web_explore, only call low-level web tools if there is a specific unresolved gap. ' +
-        'Do not keep searching or fetching just for extra confirmation.'
-    };
-  });
-
-  pi.registerTool({
-    name: 'web_search',
-    label: 'Web Search',
-    description:
-      'Direct search tool for manual discovery of links and snippets. Use for explicit search requests or when the user wants raw search results. Prefer web_explore for broader research questions.',
-    parameters: Type.Object({
-      query: Type.String({ description: 'Search query.' })
-    }),
-    async execute(_toolCallId, params) {
-      if (webExploreUsedInCurrentFlow) {
-        return guardSearchResponse();
-      }
-
-      const result = await webSearch({ query: params.query });
-      return {
-        content: [{ type: 'text', text: await renderToolText(pi, 'web_search', result) }],
-        details: result,
-        isError: result.status === 'error'
-      };
-    }
-  });
-
-  pi.registerTool({
-    name: 'web_fetch',
-    label: 'Web Fetch',
-    description:
-      'Direct HTTP page fetch for a specific URL. Use when the user wants one page read directly. Prefer web_explore for broader research across multiple sources.',
-    parameters: Type.Object({
-      url: Type.String({ description: 'HTTP or HTTPS URL to fetch.' })
-    }),
-    async execute(_toolCallId, params) {
-      if (webExploreUsedInCurrentFlow) {
-        return guardFetchResponse(params.url);
-      }
-
-      const result = await webFetch({ url: params.url });
-      return {
-        content: [{ type: 'text', text: await renderToolText(pi, 'web_fetch', result) }],
-        details: result,
-        isError: result.status === 'error'
-      };
-    }
-  });
-
-  pi.registerTool({
-    name: 'web_fetch_headless',
-    label: 'Web Fetch Headless',
-    description:
-      'Direct headless page fetch for a specific URL when browser rendering is explicitly needed. Prefer web_explore for research tasks; it decides headless escalation internally.',
-    parameters: Type.Object({
-      url: Type.String({ description: 'HTTP or HTTPS URL to fetch in headless mode.' })
-    }),
-    async execute(_toolCallId, params) {
-      if (webExploreUsedInCurrentFlow) {
-        return guardHeadlessResponse(params.url);
-      }
-
-      const result = await webFetchHeadless({ url: params.url });
-      return {
-        content: [{ type: 'text', text: await renderToolText(pi, 'web_fetch_headless', result) }],
-        details: result,
-        isError: result.status === 'error'
-      };
-    }
-  });
+  pi.on('before_agent_start', async (event) => ({
+    systemPrompt:
+      `${event.systemPrompt}\n\n` +
+      'For web research questions that require finding and comparing sources, use web_explore. ' +
+      'web_explore handles search, fetch, source ranking, and headless escalation internally.'
+  }));
 
   pi.registerTool({
     name: 'web_explore',
     label: 'Web Explore',
     description:
-      'Research a web question using bounded search/fetch passes, source ranking, and targeted headless escalation. Prefer this for multi-source web research, current docs/discussion lookups, and recommendation summaries. Use this instead of chaining low-level web tools for the same research task.',
+      'Research a web question using bounded search/fetch passes, source ranking, and targeted headless escalation. Use this for web research, current docs/discussion lookups, and recommendation summaries.',
     parameters: Type.Object({
       query: Type.String({ description: 'Web research question to explore.' })
     }),
     async execute(_toolCallId, params) {
       const result: WebExploreResponse = await webExplore({ query: params.query });
-      if (result.status === 'ok') {
-        webExploreUsedInCurrentFlow = true;
-      }
-
       return {
         content: [
           {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,8 @@ export default function extension(pi: ExtensionAPI) {
     systemPrompt:
       `${event.systemPrompt}\n\n` +
       'For web research questions that require finding and comparing sources, use web_explore. ' +
-      'web_explore handles search, fetch, source ranking, and headless escalation internally.'
+      'web_explore handles search, fetch, source ranking, and headless escalation internally. ' +
+      'If more web evidence is needed after web_explore, call web_explore again with a narrower query; do not use shell/network commands such as curl, Invoke-WebRequest, npm view/search/pack, or direct HTTP URLs for web research.'
   }));
 
   pi.registerTool({

--- a/src/orchestration/answer-synthesizer.ts
+++ b/src/orchestration/answer-synthesizer.ts
@@ -1,0 +1,21 @@
+import type { ResearchEvidence } from './research-types.js';
+
+function normalizeSummary(summary: string) {
+  return summary.replace(/\s+/g, ' ').trim();
+}
+
+export function synthesizeAnswer({ evidence, partial }: { evidence: ResearchEvidence[]; partial: boolean }) {
+  const findings = evidence.slice(0, 5).map((item) => {
+    const summary = normalizeSummary(item.summary);
+    return item.sourceKind === 'community' || item.sourceKind === 'issue-thread'
+      ? `Community/practical context: ${summary}`
+      : summary;
+  });
+
+  return {
+    findings,
+    caveat: partial
+      ? 'Evidence is partial, so this answer is based on the strongest source found within the bounded research budget.'
+      : undefined
+  };
+}

--- a/src/orchestration/candidate-selector.ts
+++ b/src/orchestration/candidate-selector.ts
@@ -1,0 +1,30 @@
+import type { SearchResult } from '../types.js';
+
+function candidateScore(result: SearchResult) {
+  const url = result.url.toLowerCase();
+  if (url.includes('playwright.dev/docs') || url.includes('vitest.dev/guide') || url.includes('learn.microsoft.com')) return 0;
+  if (url.includes('github.com/') && (url.includes('/issues/') || url.includes('/discussions/'))) return 1;
+  if (url.includes('github.com/')) return 2;
+  if (url.includes('npmjs.com/package/')) return 4;
+  return 3;
+}
+
+export function selectCandidates({
+  results,
+  seenUrls,
+  maxCandidates
+}: {
+  results: SearchResult[];
+  seenUrls: Set<string>;
+  maxCandidates: number;
+}) {
+  const deduped = new Map<string, SearchResult>();
+  for (const result of results) {
+    if (seenUrls.has(result.url)) continue;
+    if (!deduped.has(result.url)) deduped.set(result.url, result);
+  }
+
+  return [...deduped.values()]
+    .sort((left, right) => candidateScore(left) - candidateScore(right))
+    .slice(0, maxCandidates);
+}

--- a/src/orchestration/evidence-ranker.ts
+++ b/src/orchestration/evidence-ranker.ts
@@ -1,0 +1,45 @@
+import type { ResearchEvidence } from './research-types.js';
+
+function sourceRank(sourceKind: ResearchEvidence['sourceKind']) {
+  switch (sourceKind) {
+    case 'official-docs':
+      return 0;
+    case 'official-api':
+      return 1;
+    case 'official-discussion':
+      return 2;
+    case 'issue-thread':
+      return 3;
+    case 'community':
+      return 4;
+    case 'package-page':
+      return 5;
+    default:
+      return 6;
+  }
+}
+
+export function rankEvidence(evidence: ResearchEvidence[]) {
+  const bestByUrl = new Map<string, ResearchEvidence>();
+  for (const item of evidence) {
+    const current = bestByUrl.get(item.url);
+    if (!current || sourceRank(item.sourceKind) < sourceRank(current.sourceKind)) {
+      bestByUrl.set(item.url, item);
+    }
+  }
+
+  return [...bestByUrl.values()].sort((left, right) => sourceRank(left.sourceKind) - sourceRank(right.sourceKind));
+}
+
+export function hasOfficialEvidence(evidence: ResearchEvidence[]) {
+  return evidence.some((item) => item.sourceKind === 'official-docs' || item.sourceKind === 'official-api');
+}
+
+export function strongEvidenceCount(evidence: ResearchEvidence[]) {
+  return evidence.filter(
+    (item) =>
+      item.sourceKind === 'official-docs' ||
+      item.sourceKind === 'official-api' ||
+      item.sourceKind === 'official-discussion'
+  ).length;
+}

--- a/src/orchestration/query-planner.ts
+++ b/src/orchestration/query-planner.ts
@@ -1,0 +1,47 @@
+export type QueryPlanInput = {
+  originalQuery: string;
+  passIndex: number;
+  previousQueries: string[];
+  gaps: string[];
+};
+
+function normalizeWhitespace(value: string) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function extractImportantWords(query: string) {
+  return normalizeWhitespace(query)
+    .replace(/\b(find|current|tell|me|how|to|the|and|with|for|in|a|an)\b/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function officialSiteQuery(query: string) {
+  const lower = query.toLowerCase();
+  const terms = extractImportantWords(query);
+  if (lower.includes('vitest')) return `site:vitest.dev ${terms}`;
+  if (lower.includes('playwright')) return `site:playwright.dev ${terms}`;
+  if (lower.includes('microsoft edge') || lower.includes('edge')) return `site:learn.microsoft.com ${terms}`;
+  return `${terms} official docs`;
+}
+
+function implementationQuery(query: string) {
+  return `site:github.com ${extractImportantWords(query)}`;
+}
+
+export function planSearchQueries(input: QueryPlanInput): string[] {
+  const planned =
+    input.passIndex === 0
+      ? [input.originalQuery]
+      : [
+          officialSiteQuery(input.originalQuery),
+          implementationQuery(input.originalQuery),
+          `${extractImportantWords(input.originalQuery)} discussion`
+        ];
+
+  const previous = new Set(input.previousQueries.map(normalizeWhitespace));
+  return planned
+    .map(normalizeWhitespace)
+    .filter((query) => query && !previous.has(query))
+    .slice(0, 3);
+}

--- a/src/orchestration/research-orchestrator.ts
+++ b/src/orchestration/research-orchestrator.ts
@@ -1,60 +1,53 @@
 import type { WebFetchHeadlessResponse } from '../types.js';
+import { rankEvidence } from './evidence-ranker.js';
+import { planSearchQueries } from './query-planner.js';
 import type {
   ResearchEvidence,
+  ResearchGap,
   ResearchLowValueOutcome,
   ResearchOrchestratorDecision,
   ResearchWorkerResult
 } from './research-types.js';
+import { decideNextResearchStep } from './stop-decider.js';
 
-function sourceRank(sourceKind: ResearchEvidence['sourceKind']): number {
-  switch (sourceKind) {
-    case 'official-docs':
-      return 0;
-    case 'official-api':
-      return 1;
-    case 'official-discussion':
-      return 2;
-    case 'issue-thread':
-      return 3;
-    case 'community':
-      return 4;
-    case 'package-page':
-      return 5;
-    default:
-      return 6;
+const DEFAULT_MAX_PASSES = 3;
+const DEFAULT_MAX_FETCHES_PER_PASS = 4;
+const DEFAULT_MAX_HEADLESS_ATTEMPTS = 2;
+
+function fallbackWorkerPass({
+  previousQueries,
+  allGaps,
+  allLowValueOutcomes,
+  exhaustedBudget
+}: {
+  previousQueries: string[];
+  allGaps: ResearchGap[];
+  allLowValueOutcomes: ResearchLowValueOutcome[];
+  exhaustedBudget: boolean;
+}): ResearchWorkerResult {
+  return {
+    searchQueries: previousQueries,
+    evidence: [],
+    gaps: allGaps,
+    lowValueOutcomes: allLowValueOutcomes,
+    exhaustedBudget
+  };
+}
+
+function decisionForAnswer(action: 'answer' | 'answer-with-caveat', query: string, ranked: ResearchEvidence[]): ResearchOrchestratorDecision {
+  if (action === 'answer') {
+    return {
+      action: 'answer',
+      rationale: 'Adaptive research gathered enough strong evidence.',
+      approvedEvidence: ranked
+    };
   }
-}
 
-function sortEvidence(evidence: ResearchEvidence[]) {
-  return [...evidence].sort((left, right) => sourceRank(left.sourceKind) - sourceRank(right.sourceKind));
-}
-
-function strongEvidence(evidence: ResearchEvidence[]) {
-  return evidence.filter(
-    (item) =>
-      item.sourceKind === 'official-docs' ||
-      item.sourceKind === 'official-api' ||
-      item.sourceKind === 'official-discussion'
-  );
-}
-
-function hasOfficialDocsOrApi(evidence: ResearchEvidence[]) {
-  return evidence.some(
-    (item) => item.sourceKind === 'official-docs' || item.sourceKind === 'official-api'
-  );
-}
-
-function hasBotCheck(outcomes: ResearchLowValueOutcome[]) {
-  return outcomes.some((outcome) => outcome.kind === 'bot-check');
-}
-
-function isHeadlessWorthTrying(pass: ResearchWorkerResult, approvedEvidence: ResearchEvidence[]) {
-  if (!pass.suggestedHeadlessUrl) return false;
-  if (hasBotCheck(pass.lowValueOutcomes)) return false;
-  if (approvedEvidence.length >= 2 && hasOfficialDocsOrApi(approvedEvidence)) return false;
-
-  const candidate = pass.suggestedHeadlessUrl;
-  return !candidate.includes('npmjs.com/package/');
+  return {
+    action: 'research-again',
+    rationale: 'Research budget exhausted; answer with caveat.',
+    followupQuery: query
+  };
 }
 
 export function createResearchOrchestrator({
@@ -72,56 +65,84 @@ export function createResearchOrchestrator({
 }) {
   return {
     async run({ query }: { query: string }) {
-      const pass = await worker.run({ query, maxSearchRounds: 1, maxFetches: 3 });
-      const approvedEvidence = sortEvidence(
-        pass.evidence.filter((item) => item.sourceKind !== 'package-page')
-      );
-      const strong = strongEvidence(approvedEvidence);
-      const enoughEvidence = strong.length >= 2 && hasOfficialDocsOrApi(approvedEvidence);
+      const allEvidence: ResearchEvidence[] = [];
+      const allGaps: ResearchGap[] = [];
+      const allLowValueOutcomes: ResearchLowValueOutcome[] = [];
+      const previousQueries: string[] = [];
+      const suggestedHeadlessUrls: string[] = [];
+      let headlessAttempts = 0;
+      let lastPass: ResearchWorkerResult | undefined;
 
-      if (enoughEvidence) {
-        const decision: ResearchOrchestratorDecision = {
-          action: 'answer',
-          rationale: 'Two strong sources with official support are enough to answer safely.',
-          approvedEvidence
-        };
+      for (let passIndex = 0; passIndex < DEFAULT_MAX_PASSES; passIndex++) {
+        const queries = planSearchQueries({
+          originalQuery: query,
+          passIndex,
+          previousQueries,
+          gaps: allGaps.map((gap) => gap.message)
+        });
 
-        return { decision, evidence: approvedEvidence, workerPass: pass };
+        for (const plannedQuery of queries) {
+          previousQueries.push(plannedQuery);
+          const pass = await worker.run({
+            query: plannedQuery,
+            maxSearchRounds: 1,
+            maxFetches: DEFAULT_MAX_FETCHES_PER_PASS
+          });
+
+          lastPass = pass;
+          allEvidence.push(...pass.evidence);
+          allGaps.push(...pass.gaps);
+          allLowValueOutcomes.push(...pass.lowValueOutcomes);
+          if (pass.suggestedHeadlessUrl) suggestedHeadlessUrls.push(pass.suggestedHeadlessUrl);
+
+          const ranked = rankEvidence(allEvidence.filter((item) => item.sourceKind !== 'package-page'));
+          const decision = decideNextResearchStep({
+            evidence: ranked,
+            suggestedHeadlessUrls,
+            passIndex,
+            maxPasses: DEFAULT_MAX_PASSES,
+            headlessAttempts,
+            maxHeadlessAttempts: DEFAULT_MAX_HEADLESS_ATTEMPTS
+          });
+
+          if (decision.action === 'headless') {
+            headlessAttempts++;
+            await headlessFetch({ url: decision.url });
+            return {
+              decision: {
+                action: 'escalate-headless',
+                rationale: 'One high-value page is worth a single orchestrator-approved headless retry.',
+                url: decision.url,
+                approvedEvidence: ranked
+              } satisfies ResearchOrchestratorDecision,
+              evidence: ranked,
+              workerPass: lastPass
+            };
+          }
+
+          if (decision.action === 'answer' || decision.action === 'answer-with-caveat') {
+            return {
+              decision: decisionForAnswer(decision.action, query, ranked),
+              evidence: ranked,
+              workerPass: lastPass
+            };
+          }
+        }
       }
 
-      if (isHeadlessWorthTrying(pass, approvedEvidence)) {
-        const url = pass.suggestedHeadlessUrl!;
-        await headlessFetch({ url });
-        const decision: ResearchOrchestratorDecision = {
-          action: 'escalate-headless',
-          rationale: 'One high-value page is worth a single orchestrator-approved headless retry.',
-          url,
-          approvedEvidence
-        };
-
-        return { decision, evidence: approvedEvidence, workerPass: pass };
-      }
-
-      const hasConcreteGap = pass.gaps.length > 0;
-      const onlyLowValueOutcomes = pass.lowValueOutcomes.length > 0 && pass.evidence.length === 0;
-
-      if (!hasConcreteGap || onlyLowValueOutcomes) {
-        const decision: ResearchOrchestratorDecision = {
-          action: 'research-again',
-          rationale: 'Current results did not justify more escalation; continue only with a more targeted pass.',
-          followupQuery: query
-        };
-
-        return { decision, evidence: approvedEvidence, workerPass: pass };
-      }
-
-      const decision: ResearchOrchestratorDecision = {
-        action: 'research-again',
-        rationale: 'The first pass did not gather enough strong evidence to answer safely.',
-        followupQuery: query
+      const ranked = rankEvidence(allEvidence.filter((item) => item.sourceKind !== 'package-page'));
+      return {
+        decision: decisionForAnswer('answer-with-caveat', query, ranked),
+        evidence: ranked,
+        workerPass:
+          lastPass ??
+          fallbackWorkerPass({
+            previousQueries,
+            allGaps,
+            allLowValueOutcomes,
+            exhaustedBudget: true
+          })
       };
-
-      return { decision, evidence: approvedEvidence, workerPass: pass };
     }
   };
 }

--- a/src/orchestration/research-orchestrator.ts
+++ b/src/orchestration/research-orchestrator.ts
@@ -14,6 +14,33 @@ const DEFAULT_MAX_PASSES = 3;
 const DEFAULT_MAX_FETCHES_PER_PASS = 4;
 const DEFAULT_MAX_HEADLESS_ATTEMPTS = 2;
 
+function classifyEvidenceUrl(url: string): ResearchEvidence['sourceKind'] {
+  if (url.includes('/docs/api/') || url.includes('/config/')) return 'official-api';
+  if (url.includes('playwright.dev/docs') || url.includes('vitest.dev/guide/')) return 'official-docs';
+  if (url.includes('github.com/vitest-dev/vitest') && url.includes('/docs/')) return 'official-docs';
+  if (url.includes('learn.microsoft.com')) return 'official-docs';
+  if (url.includes('github.com/') && url.includes('/issues/')) return 'issue-thread';
+  if (url.includes('npmjs.com/package/')) return 'package-page';
+  return 'community';
+}
+
+function summarizeText(text: string, maxLength = 180): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function evidenceFromHeadless(result: WebFetchHeadlessResponse): ResearchEvidence | null {
+  if (result.status !== 'ok' || !result.content?.text.trim()) return null;
+
+  return {
+    title: result.content.title ?? result.url,
+    url: result.url,
+    sourceKind: classifyEvidenceUrl(result.url),
+    method: 'headless',
+    summary: summarizeText(result.content.text),
+    supports: [summarizeText(result.content.text, 120)]
+  };
+}
+
 function fallbackWorkerPass({
   previousQueries,
   allGaps,
@@ -30,6 +57,29 @@ function fallbackWorkerPass({
     evidence: [],
     gaps: allGaps,
     lowValueOutcomes: allLowValueOutcomes,
+    exhaustedBudget
+  };
+}
+
+function buildMetadata({
+  previousQueries,
+  allEvidence,
+  allGaps,
+  allLowValueOutcomes,
+  headlessAttempts,
+  exhaustedBudget
+}: {
+  previousQueries: string[];
+  allEvidence: ResearchEvidence[];
+  allGaps: ResearchGap[];
+  allLowValueOutcomes: ResearchLowValueOutcome[];
+  headlessAttempts: number;
+  exhaustedBudget: boolean;
+}) {
+  return {
+    searchPasses: previousQueries.length,
+    fetchedPages: allEvidence.length + allGaps.length + allLowValueOutcomes.length,
+    headlessAttempts,
     exhaustedBudget
   };
 }
@@ -107,7 +157,39 @@ export function createResearchOrchestrator({
 
           if (decision.action === 'headless') {
             headlessAttempts++;
-            await headlessFetch({ url: decision.url });
+            const headlessResult = await headlessFetch({ url: decision.url });
+            const headlessEvidence = evidenceFromHeadless(headlessResult);
+            if (headlessEvidence) {
+              allEvidence.push(headlessEvidence);
+              const updatedRanked = rankEvidence(allEvidence.filter((item) => item.sourceKind !== 'package-page'));
+              const updatedDecision = decideNextResearchStep({
+                evidence: updatedRanked,
+                suggestedHeadlessUrls: [],
+                passIndex,
+                maxPasses: DEFAULT_MAX_PASSES,
+                headlessAttempts,
+                maxHeadlessAttempts: DEFAULT_MAX_HEADLESS_ATTEMPTS
+              });
+
+              return {
+                decision: decisionForAnswer(
+                  updatedDecision.action === 'answer' ? 'answer' : 'answer-with-caveat',
+                  query,
+                  updatedRanked
+                ),
+                evidence: updatedRanked,
+                workerPass: lastPass,
+                metadata: buildMetadata({
+                  previousQueries,
+                  allEvidence,
+                  allGaps,
+                  allLowValueOutcomes,
+                  headlessAttempts,
+                  exhaustedBudget: updatedDecision.action !== 'answer'
+                })
+              };
+            }
+
             return {
               decision: {
                 action: 'escalate-headless',
@@ -116,7 +198,15 @@ export function createResearchOrchestrator({
                 approvedEvidence: ranked
               } satisfies ResearchOrchestratorDecision,
               evidence: ranked,
-              workerPass: lastPass
+              workerPass: lastPass,
+              metadata: buildMetadata({
+                previousQueries,
+                allEvidence,
+                allGaps,
+                allLowValueOutcomes,
+                headlessAttempts,
+                exhaustedBudget: false
+              })
             };
           }
 
@@ -124,7 +214,15 @@ export function createResearchOrchestrator({
             return {
               decision: decisionForAnswer(decision.action, query, ranked),
               evidence: ranked,
-              workerPass: lastPass
+              workerPass: lastPass,
+              metadata: buildMetadata({
+                previousQueries,
+                allEvidence,
+                allGaps,
+                allLowValueOutcomes,
+                headlessAttempts,
+                exhaustedBudget: decision.action === 'answer-with-caveat'
+              })
             };
           }
         }
@@ -141,7 +239,15 @@ export function createResearchOrchestrator({
             allGaps,
             allLowValueOutcomes,
             exhaustedBudget: true
-          })
+          }),
+        metadata: buildMetadata({
+          previousQueries,
+          allEvidence,
+          allGaps,
+          allLowValueOutcomes,
+          headlessAttempts,
+          exhaustedBudget: true
+        })
       };
     }
   };

--- a/src/orchestration/research-orchestrator.ts
+++ b/src/orchestration/research-orchestrator.ts
@@ -28,8 +28,15 @@ function summarizeText(text: string, maxLength = 180): string {
   return text.replace(/\s+/g, ' ').trim().slice(0, maxLength);
 }
 
+function isBotCheckContent({ title = '', text }: { title?: string; text: string }) {
+  return /performing security verification|security service|verify you are not a bot|just a moment|checking your browser/i.test(
+    `${title}\n${text}`
+  );
+}
+
 function evidenceFromHeadless(result: WebFetchHeadlessResponse): ResearchEvidence | null {
   if (result.status !== 'ok' || !result.content?.text.trim()) return null;
+  if (isBotCheckContent({ title: result.content.title, text: result.content.text })) return null;
 
   return {
     title: result.content.title ?? result.url,

--- a/src/orchestration/research-types.ts
+++ b/src/orchestration/research-types.ts
@@ -38,6 +38,13 @@ export type ResearchWorkerResult = {
   exhaustedBudget: boolean;
 };
 
+export type ResearchRunMetadata = {
+  searchPasses: number;
+  fetchedPages: number;
+  headlessAttempts: number;
+  exhaustedBudget: boolean;
+};
+
 export type ResearchOrchestratorDecision =
   | {
       action: 'answer';

--- a/src/orchestration/research-worker.ts
+++ b/src/orchestration/research-worker.ts
@@ -1,4 +1,5 @@
 import type { WebFetchResponse, WebSearchResponse } from '../types.js';
+import { selectCandidates } from './candidate-selector.js';
 import type {
   ResearchEvidence,
   ResearchGap,
@@ -10,6 +11,7 @@ import type {
 function classifySource(url: string): ResearchSourceKind {
   if (url.includes('/docs/api/') || url.includes('/config/')) return 'official-api';
   if (url.includes('playwright.dev/docs') || url.includes('vitest.dev/guide/')) return 'official-docs';
+  if (url.includes('github.com/vitest-dev/vitest') && url.includes('/docs/')) return 'official-docs';
   if (url.includes('learn.microsoft.com')) return 'official-docs';
   if (url.includes('github.com/') && url.includes('/issues/')) return 'issue-thread';
   if (url.includes('npmjs.com/package/')) return 'package-page';
@@ -117,7 +119,11 @@ export function createResearchWorker({
         };
       }
 
-      const candidates = searchResult.results.slice(0, maxFetches);
+      const candidates = selectCandidates({
+        results: searchResult.results,
+        seenUrls: new Set(evidence.map((item) => item.url)),
+        maxCandidates: maxFetches
+      });
 
       for (const candidate of candidates) {
         const fetched = await fetchPage({ url: candidate.url });

--- a/src/orchestration/stop-decider.ts
+++ b/src/orchestration/stop-decider.ts
@@ -1,0 +1,39 @@
+import type { ResearchEvidence } from './research-types.js';
+import { hasOfficialEvidence, strongEvidenceCount } from './evidence-ranker.js';
+
+export type ResearchStepDecision =
+  | { action: 'answer' }
+  | { action: 'answer-with-caveat' }
+  | { action: 'search-again' }
+  | { action: 'headless'; url: string };
+
+export function decideNextResearchStep({
+  evidence,
+  suggestedHeadlessUrls,
+  passIndex,
+  maxPasses,
+  headlessAttempts,
+  maxHeadlessAttempts
+}: {
+  evidence: ResearchEvidence[];
+  suggestedHeadlessUrls: string[];
+  passIndex: number;
+  maxPasses: number;
+  headlessAttempts: number;
+  maxHeadlessAttempts: number;
+}): ResearchStepDecision {
+  if (strongEvidenceCount(evidence) >= 2 && hasOfficialEvidence(evidence)) {
+    return { action: 'answer' };
+  }
+
+  const headlessUrl = suggestedHeadlessUrls.find((url) => !url.includes('npmjs.com/package/'));
+  if (headlessUrl && headlessAttempts < maxHeadlessAttempts) {
+    return { action: 'headless', url: headlessUrl };
+  }
+
+  if (passIndex + 1 < maxPasses) {
+    return { action: 'search-again' };
+  }
+
+  return { action: 'answer-with-caveat' };
+}

--- a/src/presentation/explore-presentation.ts
+++ b/src/presentation/explore-presentation.ts
@@ -1,6 +1,12 @@
 import type { WebExploreResponse } from '../types.js';
 import type { PresentationEnvelope } from './types.js';
 
+function internalReaderLabel(method?: 'http' | 'headless') {
+  if (method === 'headless') return 'web_fetch_headless';
+  if (method === 'http') return 'web_fetch';
+  return 'web_explore';
+}
+
 export function buildExplorePresentation(result: WebExploreResponse): PresentationEnvelope {
   if (result.status === 'error') {
     return {
@@ -11,13 +17,22 @@ export function buildExplorePresentation(result: WebExploreResponse): Presentati
     };
   }
 
-  const preview = result.findings.map((finding) => `- ${finding}`).join('\n');
+  const internalSummary = result.metadata
+    ? `Internal research: web_search ×${result.metadata.searchPasses}, web_fetch ×${result.metadata.fetchedPages}, web_fetch_headless ×${result.metadata.headlessAttempts}`
+    : undefined;
+  const preview = [
+    ...result.findings.map((finding, index) => `- [${internalReaderLabel(result.sources[index]?.method)}] ${finding}`),
+    internalSummary ? `\n${internalSummary}` : undefined
+  ]
+    .filter((line) => line !== undefined)
+    .join('\n');
   const verbose = [
     'Findings',
-    ...result.findings.map((finding) => `- ${finding}`),
+    ...result.findings.map((finding, index) => `- [${internalReaderLabel(result.sources[index]?.method)}] ${finding}`),
     '',
     'Sources',
-    ...result.sources.map((source) => `- ${source.title}: ${source.url}`),
+    ...result.sources.map((source) => `- [${internalReaderLabel(source.method)}] ${source.title}: ${source.url}`),
+    internalSummary ? `\nInternal tools\n${internalSummary}` : undefined,
     result.caveat ? `\nCaveat\n${result.caveat}` : undefined
   ]
     .filter((line) => line !== undefined)

--- a/src/presentation/explore-presentation.ts
+++ b/src/presentation/explore-presentation.ts
@@ -20,15 +20,19 @@ export function buildExplorePresentation(result: WebExploreResponse): Presentati
   const internalSummary = result.metadata
     ? `Internal research: web_search ×${result.metadata.searchPasses}, web_fetch ×${result.metadata.fetchedPages}, web_fetch_headless ×${result.metadata.headlessAttempts}`
     : undefined;
+  const hasEvidence = result.findings.length > 0 || result.sources.length > 0;
+  const evidenceLines = hasEvidence
+    ? result.findings.map((finding, index) => `- [${internalReaderLabel(result.sources[index]?.method)}] ${finding}`)
+    : ['No usable evidence found.'];
   const preview = [
-    ...result.findings.map((finding, index) => `- [${internalReaderLabel(result.sources[index]?.method)}] ${finding}`),
+    ...evidenceLines,
     internalSummary ? `\n${internalSummary}` : undefined
   ]
     .filter((line) => line !== undefined)
     .join('\n');
   const verbose = [
     'Findings',
-    ...result.findings.map((finding, index) => `- [${internalReaderLabel(result.sources[index]?.method)}] ${finding}`),
+    ...evidenceLines,
     '',
     'Sources',
     ...result.sources.map((source) => `- [${internalReaderLabel(source.method)}] ${source.title}: ${source.url}`),
@@ -41,7 +45,9 @@ export function buildExplorePresentation(result: WebExploreResponse): Presentati
   return {
     mode: 'compact',
     views: {
-      compact: `Reviewed ${result.sources.length} sources · synthesized answer with ${result.findings.length} findings`,
+      compact: hasEvidence
+        ? `Reviewed ${result.sources.length} sources · synthesized answer with ${result.findings.length} findings`
+        : 'No usable evidence found',
       preview,
       verbose
     },

--- a/src/tools/web-explore.ts
+++ b/src/tools/web-explore.ts
@@ -13,12 +13,14 @@ export function createWebExploreTool({
           decision: { action: 'answer' | 'research-again' | 'escalate-headless' };
           evidence: ResearchEvidence[];
           workerPass: unknown;
+          metadata?: WebExploreResponse['metadata'];
         }>;
       }
     | ((input: { query: string }) => Promise<{
         decision: { action: 'answer' | 'research-again' | 'escalate-headless' };
         evidence: ResearchEvidence[];
         workerPass: unknown;
+        metadata?: WebExploreResponse['metadata'];
       }>);
 } = {}) {
   const runExplore = typeof explore === 'function' ? explore : explore.run.bind(explore);
@@ -43,7 +45,8 @@ export function createWebExploreTool({
     const result = await runExplore({ query: normalizedQuery });
     const sources = result.evidence.slice(0, 4).map((item) => ({
       title: item.title,
-      url: item.url
+      url: item.url,
+      method: item.method
     }));
     const synthesized = synthesizeAnswer({
       evidence: result.evidence,
@@ -54,7 +57,8 @@ export function createWebExploreTool({
       status: 'ok',
       findings: synthesized.findings,
       sources,
-      caveat: synthesized.caveat
+      caveat: synthesized.caveat,
+      metadata: result.metadata
     };
 
     return {

--- a/src/tools/web-explore.ts
+++ b/src/tools/web-explore.ts
@@ -1,26 +1,8 @@
 import { createResearchWorkflow } from '../orchestration/index.js';
-import { buildExplorePresentation } from '../presentation/explore-presentation.js';
+import { synthesizeAnswer } from '../orchestration/answer-synthesizer.js';
 import type { ResearchEvidence } from '../orchestration/research-types.js';
+import { buildExplorePresentation } from '../presentation/explore-presentation.js';
 import type { WebExploreResponse } from '../types.js';
-
-function findingFromEvidence(evidence: ResearchEvidence, index: number): string {
-  if (evidence.summary.includes('Use channel')) {
-    return 'Use channel for branded Chrome or Edge when possible.';
-  }
-
-  if (evidence.summary.includes('use at your own risk') || evidence.summary.includes('risky')) {
-    return 'Treat executablePath as a fallback because Playwright documents it as use-at-your-own-risk.';
-  }
-
-  if (
-    evidence.summary.includes('coverage.provider to v8') ||
-    evidence.summary.includes('@vitest/coverage-v8')
-  ) {
-    return 'Vitest coverage docs say to set coverage.provider to v8 and install @vitest/coverage-v8.';
-  }
-
-  return evidence.summary || `Finding ${index + 1}`;
-}
 
 export function createWebExploreTool({
   explore = createResearchWorkflow()
@@ -59,21 +41,20 @@ export function createWebExploreTool({
     }
 
     const result = await runExplore({ query: normalizedQuery });
-    const findings = result.evidence.slice(0, 5).map(findingFromEvidence);
     const sources = result.evidence.slice(0, 4).map((item) => ({
       title: item.title,
       url: item.url
     }));
-    const caveat =
-      result.decision.action === 'answer'
-        ? undefined
-        : 'Evidence is partial, so this answer is based on the strongest source found so far.';
+    const synthesized = synthesizeAnswer({
+      evidence: result.evidence,
+      partial: result.decision.action !== 'answer'
+    });
 
     const shaped: WebExploreResponse = {
       status: 'ok',
-      findings,
+      findings: synthesized.findings,
       sources,
-      caveat
+      caveat: synthesized.caveat
     };
 
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,8 +70,14 @@ export type WebFetchHeadlessResponse = {
 export type WebExploreResponse = {
   status: 'ok' | 'error';
   findings: string[];
-  sources: Array<{ title: string; url: string }>;
+  sources: Array<{ title: string; url: string; method?: 'http' | 'headless' }>;
   caveat?: string;
+  metadata?: {
+    searchPasses: number;
+    fetchedPages: number;
+    headlessAttempts: number;
+    exhaustedBudget: boolean;
+  };
   presentation?: PresentationEnvelope;
   error?: ToolError;
 };

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function workflow(name: string) {
+  return readFileSync(path.join(process.cwd(), '.github', 'workflows', name), 'utf8');
+}
+
+describe('CI workflows', () => {
+  it('builds from npm ci without patch-installing Rollup optional packages', () => {
+    for (const name of ['ci.yml', 'docs.yml', 'publish.yml']) {
+      const text = workflow(name);
+      expect(text).toContain('npm ci');
+      expect(text).not.toContain('npm install --no-save @rollup/rollup-linux-x64-gnu');
+    }
+  });
+});

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -23,7 +23,7 @@ describe('web-agent config draft helpers', () => {
         path: '/project/config.json',
         exists: true,
         rawConfig: {
-          tools: { web_search: { mode: 'compact' as const } }
+          tools: { web_explore: { mode: 'compact' as const } }
         }
       },
       effectiveConfig: mergePresentationConfigLayers(
@@ -33,7 +33,7 @@ describe('web-agent config draft helpers', () => {
           tools: { web_explore: { mode: 'verbose' } }
         },
         {
-          tools: { web_search: { mode: 'compact' } }
+          tools: { web_explore: { mode: 'compact' } }
         }
       )
     };
@@ -44,7 +44,7 @@ describe('web-agent config draft helpers', () => {
     expect(initialState.scope).toBe('project');
     expect(initialState.config).toEqual({
       defaultMode: 'preview',
-      tools: { web_explore: { mode: 'verbose' }, web_search: { mode: 'compact' } }
+      tools: { web_explore: { mode: 'compact' } }
     });
     expect(switchedState.scope).toBe('global');
     expect(switchedState.config).toEqual({
@@ -58,7 +58,7 @@ describe('web-agent config draft helpers', () => {
       collapsePresentationConfigToOverride(
         {
           defaultMode: 'preview',
-          tools: { web_search: { mode: 'verbose' } }
+          tools: { web_explore: { mode: 'verbose' } }
         },
         {
           defaultMode: 'preview',
@@ -66,7 +66,7 @@ describe('web-agent config draft helpers', () => {
         }
       )
     ).toEqual({
-      tools: { web_search: { mode: 'verbose' } }
+      tools: { web_explore: { mode: 'verbose' } }
     });
   });
 
@@ -108,11 +108,11 @@ describe('web-agent config commands', () => {
         project: {
           path: '/project/config.json',
           exists: true,
-          rawConfig: { defaultMode: 'preview', tools: { web_search: { mode: 'verbose' } } }
+          rawConfig: { defaultMode: 'preview', tools: { web_explore: { mode: 'verbose' } } }
         },
         effectiveConfig: {
           defaultMode: 'preview',
-          tools: { web_search: { mode: 'verbose' } }
+          tools: { web_explore: { mode: 'verbose' } }
         }
       }),
       reset: vi.fn()
@@ -122,7 +122,9 @@ describe('web-agent config commands', () => {
     await handler('show', { ui: { notify } });
 
     expect(notify).toHaveBeenCalledWith(expect.stringContaining('defaultMode: preview'), 'info');
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining('web_search: verbose'), 'info');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('web_explore: verbose'), 'info');
+    expect(notify.mock.calls[0][0]).not.toContain('web_search:');
+    expect(notify.mock.calls[0][0]).not.toContain('web_fetch:');
   });
 
   it('resets project scope when explicitly requested', async () => {
@@ -168,7 +170,7 @@ describe('web-agent config commands', () => {
       scope: 'project',
       config: {
         defaultMode: 'preview',
-        tools: { web_search: { mode: 'verbose' } }
+        tools: { web_explore: { mode: 'verbose' } }
       },
       action: 'save'
     });
@@ -200,7 +202,7 @@ describe('web-agent config commands', () => {
       scope: 'project',
       config: {
         defaultMode: 'preview',
-        tools: { web_search: { mode: 'verbose' } }
+        tools: { web_explore: { mode: 'verbose' } }
       },
       action: 'save'
     });
@@ -342,11 +344,37 @@ describe('web-agent config commands', () => {
       reset: vi.fn()
     });
 
-    await handler('mode web_search verbose', { ui: { notify: vi.fn() } });
+    await handler('mode web_explore verbose', { ui: { notify: vi.fn() } });
 
     expect(save).toHaveBeenCalledWith('project', {
-      tools: { web_search: { mode: 'verbose' } }
+      tools: { web_explore: { mode: 'verbose' } }
     });
+  });
+
+  it('rejects removed low-level tool names in mode command', async () => {
+    let handler: any;
+    const save = vi.fn();
+    const notify = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: { path: '/project/config.json', exists: false },
+        effectiveConfig: { defaultMode: 'compact', tools: {} }
+      }),
+      save,
+      reset: vi.fn()
+    });
+
+    await handler('mode web_search verbose', { ui: { notify } });
+
+    expect(save).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Usage:'), 'info');
   });
 
   it('clears a per-tool override when inherit is requested', async () => {
@@ -364,18 +392,18 @@ describe('web-agent config commands', () => {
         project: {
           path: '/project/config.json',
           exists: true,
-          rawConfig: { defaultMode: 'compact', tools: { web_search: { mode: 'preview' } } }
+          rawConfig: { defaultMode: 'compact', tools: { web_explore: { mode: 'preview' } } }
         },
         effectiveConfig: {
           defaultMode: 'compact',
-          tools: { web_search: { mode: 'preview' } }
+          tools: { web_explore: { mode: 'preview' } }
         }
       }),
       save,
       reset: vi.fn()
     });
 
-    await handler('mode web_search inherit', { ui: { notify: vi.fn() } });
+    await handler('mode web_explore inherit', { ui: { notify: vi.fn() } });
 
     expect(save).toHaveBeenCalledWith('project', {
       tools: {}

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -68,6 +68,8 @@ describe('Pi extension entrypoint', () => {
 
     expect(result.systemPrompt).toContain('use web_explore');
     expect(result.systemPrompt).toContain('handles search, fetch, source ranking, and headless escalation internally');
+    expect(result.systemPrompt).toContain('call web_explore again with a narrower query');
+    expect(result.systemPrompt).toContain('do not use shell/network commands');
   });
 
   it('does not register a context hook that injects reminder text into the visible session', () => {
@@ -90,7 +92,10 @@ describe('Pi extension entrypoint', () => {
     const pi = {
       registerTool: (tool: any) => tools.push(tool),
       registerCommand: vi.fn(),
-      on: vi.fn()
+      on: vi.fn(),
+      __presentationConfigStore: {
+        load: vi.fn().mockResolvedValue({ effectiveConfig: { defaultMode: 'compact', tools: {} } })
+      }
     };
 
     extension(pi as never);

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -17,60 +17,32 @@ describe('Pi extension entrypoint', () => {
     );
   });
 
-  it('registers four tools with Pi', () => {
+  it('registers only web_explore as a public Pi tool', () => {
     const registerTool = vi.fn();
     const pi = { registerTool, registerCommand: vi.fn(), on: vi.fn() };
 
     extension(pi as never);
 
-    expect(registerTool).toHaveBeenCalledTimes(4);
-    expect(registerTool.mock.calls.map((call) => call[0].name)).toEqual([
-      'web_search',
-      'web_fetch',
-      'web_fetch_headless',
-      'web_explore'
-    ]);
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registerTool.mock.calls.map((call) => call[0].name)).toEqual(['web_explore']);
   });
 
-  it('describes web_explore as the preferred tool for research-style web questions', () => {
+  it('describes web_explore as the public research entrypoint', () => {
     const registerTool = vi.fn();
     const pi = { registerTool, registerCommand: vi.fn(), on: vi.fn() };
 
     extension(pi as never);
 
-    const tools = registerTool.mock.calls.map((call) => call[0]);
-    const webExplore = tools.find((tool) => tool.name === 'web_explore');
+    const webExplore = registerTool.mock.calls.map((call) => call[0]).find((tool) => tool.name === 'web_explore');
 
     expect(webExplore).toBeDefined();
-    expect(webExplore.description).toContain('Prefer this for multi-source web research');
-    expect(webExplore.description).toContain('current docs/discussion lookups');
-    expect(webExplore.description).toContain('Use this instead of chaining low-level web tools');
+    expect(webExplore.description).toContain('Research a web question');
+    expect(webExplore.description).toContain('bounded search/fetch passes');
     expect(webExplore.parameters.properties).toHaveProperty('query');
     expect(Object.keys(webExplore.parameters.properties)).toEqual(['query']);
   });
 
-  it('describes low-level tools as direct/manual tools and points research prompts to web_explore', () => {
-    const registerTool = vi.fn();
-    const pi = { registerTool, registerCommand: vi.fn(), on: vi.fn() };
-
-    extension(pi as never);
-
-    const tools = registerTool.mock.calls.map((call) => call[0]);
-    const webSearch = tools.find((tool) => tool.name === 'web_search');
-    const webFetch = tools.find((tool) => tool.name === 'web_fetch');
-    const webFetchHeadless = tools.find((tool) => tool.name === 'web_fetch_headless');
-
-    expect(webSearch.description).toContain('Direct search tool for manual discovery');
-    expect(webSearch.description).toContain('Prefer web_explore for broader research questions');
-
-    expect(webFetch.description).toContain('Direct HTTP page fetch for a specific URL');
-    expect(webFetch.description).toContain('Prefer web_explore for broader research across multiple sources');
-
-    expect(webFetchHeadless.description).toContain('Direct headless page fetch for a specific URL');
-    expect(webFetchHeadless.description).toContain('Prefer web_explore for research tasks');
-  });
-
-  it('adds a short research hint that prefers web_explore for multi-source web questions', async () => {
+  it('adds a short research hint that web_explore handles research internally', async () => {
     const handlers = new Map<string, Function>();
     const pi = {
       registerTool: vi.fn(),
@@ -87,25 +59,15 @@ describe('Pi extension entrypoint', () => {
 
     const result = await beforeAgentStart!(
       {
-        prompt:
-          'Find current docs or discussions about Playwright launching an installed Chrome or Edge executable instead of a bundled browser, then summarize the recommended approach.',
+        prompt: 'Find current Vitest coverage docs and summarize V8 setup.',
         images: [],
         systemPrompt: 'Base system prompt'
       },
       {}
     );
 
-    expect(result.systemPrompt).toContain('prefer web_explore');
-    expect(result.systemPrompt).toContain('finding and comparing multiple sources');
-    expect(result.systemPrompt).toContain(
-      'Use web_search, web_fetch, and web_fetch_headless for direct/manual operations'
-    );
-    expect(result.systemPrompt).toContain(
-      'After using web_explore, only call low-level web tools if there is a specific unresolved gap'
-    );
-    expect(result.systemPrompt).toContain(
-      'Do not keep searching or fetching just for extra confirmation'
-    );
+    expect(result.systemPrompt).toContain('use web_explore');
+    expect(result.systemPrompt).toContain('handles search, fetch, source ranking, and headless escalation internally');
   });
 
   it('does not register a context hook that injects reminder text into the visible session', () => {
@@ -143,48 +105,6 @@ describe('Pi extension entrypoint', () => {
     expect(result.content[0].text).not.toContain('{\n');
   }, 15000);
 
-  it('returns compact output for web_search by default instead of raw json', async () => {
-    const tools: any[] = [];
-    const pi = {
-      registerTool: (tool: any) => tools.push(tool),
-      registerCommand: vi.fn(),
-      on: vi.fn()
-    };
-
-    extension(pi as never);
-
-    const webSearch = tools.find((tool) => tool.name === 'web_search');
-    const result = await webSearch.execute('tool-call-1', { query: 'plain search' });
-
-    expect(result.content[0].text).toContain('Found');
-    expect(result.content[0].text).not.toContain('{\n');
-  }, 15000);
-
-  it('prefers project config over global config for rendered output', async () => {
-    const tools: any[] = [];
-    const pi = {
-      registerTool: (tool: any) => tools.push(tool),
-      registerCommand: vi.fn(),
-      on: vi.fn(),
-      __presentationConfigStore: {
-        load: vi.fn().mockResolvedValue({
-          effectiveConfig: {
-            defaultMode: 'compact',
-            tools: { web_search: { mode: 'preview' } }
-          }
-        })
-      }
-    };
-
-    extension(pi as never);
-
-    const webSearch = tools.find((tool) => tool.name === 'web_search');
-    const result = await webSearch.execute('tool-call-1', { query: 'plain search' });
-
-    expect(result.content[0].text).toContain('1.');
-    expect(result.content[0].text).not.toContain('Found 1 result');
-  }, 15000);
-
   it('falls back to built-in defaults when the store cannot load config', async () => {
     const tools: any[] = [];
     const pi = {
@@ -198,53 +118,9 @@ describe('Pi extension entrypoint', () => {
 
     extension(pi as never);
 
-    const webSearch = tools.find((tool) => tool.name === 'web_search');
-    const result = await webSearch.execute('tool-call-1', { query: 'plain search' });
-
-    expect(result.content[0].text).toContain('Found');
-  }, 15000);
-
-  it('blocks low-level web_search after a successful web_explore in the same tool flow', async () => {
-    const tools: any[] = [];
-    const pi = {
-      registerTool: (tool: any) => tools.push(tool),
-      registerCommand: vi.fn(),
-      on: vi.fn()
-    };
-
-    extension(pi as never);
-
     const webExplore = tools.find((tool) => tool.name === 'web_explore');
-    const webSearch = tools.find((tool) => tool.name === 'web_search');
+    const result = await webExplore.execute('tool-call-1', { query: 'plain search' });
 
-    await webExplore.execute('tool-call-1', { query: 'example query' });
-    const result = await webSearch.execute('tool-call-2', { query: 'follow-up search' });
-
-    expect(result.isError).toBe(true);
-    expect(result.details).toMatchObject({
-      status: 'error',
-      error: {
-        code: 'POST_WEB_EXPLORE_GUARD',
-        message:
-          'web_explore already ran for this research task. Only use low-level web tools if there is a specific unresolved gap.'
-      }
-    });
-  }, 15000);
-
-  it('still allows low-level tools before web_explore runs', async () => {
-    const tools: any[] = [];
-    const pi = {
-      registerTool: (tool: any) => tools.push(tool),
-      registerCommand: vi.fn(),
-      on: vi.fn()
-    };
-
-    extension(pi as never);
-
-    const webSearch = tools.find((tool) => tool.name === 'web_search');
-    const result = await webSearch.execute('tool-call-1', { query: 'plain search' });
-
-    expect(result.details.status).not.toBe('error');
-    expect(result.details.error?.code).not.toBe('POST_WEB_EXPLORE_GUARD');
+    expect(result.content[0].text).toContain('Reviewed');
   }, 15000);
 });

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -95,7 +95,19 @@ describe('Pi extension entrypoint', () => {
       on: vi.fn(),
       __presentationConfigStore: {
         load: vi.fn().mockResolvedValue({ effectiveConfig: { defaultMode: 'compact', tools: {} } })
-      }
+      },
+      __webExploreTool: vi.fn().mockResolvedValue({
+        status: 'ok',
+        findings: ['A concise finding.'],
+        sources: [{ title: 'Source', url: 'https://example.com', method: 'http' }],
+        presentation: {
+          mode: 'compact',
+          views: {
+            compact: 'Reviewed 1 sources · synthesized answer with 1 findings',
+            verbose: 'Findings\n- A concise finding.'
+          }
+        }
+      })
     };
 
     extension(pi as never);
@@ -118,7 +130,18 @@ describe('Pi extension entrypoint', () => {
       on: vi.fn(),
       __presentationConfigStore: {
         load: vi.fn().mockRejectedValue(new Error('boom'))
-      }
+      },
+      __webExploreTool: vi.fn().mockResolvedValue({
+        status: 'ok',
+        findings: ['A concise finding.'],
+        sources: [{ title: 'Source', url: 'https://example.com', method: 'http' }],
+        presentation: {
+          mode: 'compact',
+          views: {
+            compact: 'Reviewed 1 sources · synthesized answer with 1 findings'
+          }
+        }
+      })
     };
 
     extension(pi as never);

--- a/tests/live-web-eval.test.ts
+++ b/tests/live-web-eval.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { buildMetrics, evaluateVerdict } from '../scripts/live-web-eval.js';
+
+describe('live web eval fallback detection', () => {
+  it('flags shell network fallbacks after web_explore', () => {
+    const metrics = buildMetrics([
+      {
+        toolName: 'web_explore',
+        args: { query: 'DuckDuckGo HTML scraping pitfalls' },
+        startedAt: '2026-01-01T00:00:00.000Z'
+      },
+      {
+        toolName: 'bash',
+        args: { command: "powershell -Command \"Invoke-WebRequest https://html.duckduckgo.com/html/?q=nodejs\"" },
+        startedAt: '2026-01-01T00:00:01.000Z'
+      }
+    ]);
+
+    expect(metrics.networkShellFallbacksAfterExplore).toBe(1);
+    expect(evaluateVerdict(metrics, 'answer text')).toEqual({
+      verdict: 'mixed',
+      notes: ['network-capable shell fallback after web_explore (1)']
+    });
+  });
+
+  it('does not flag local shell checks', () => {
+    const metrics = buildMetrics([
+      {
+        toolName: 'bash',
+        args: { command: "powershell -Command \"Test-Path 'learning/_index.md'\"" },
+        startedAt: '2026-01-01T00:00:00.000Z'
+      },
+      {
+        toolName: 'web_explore',
+        args: { query: 'Vitest coverage docs' },
+        startedAt: '2026-01-01T00:00:01.000Z'
+      }
+    ]);
+
+    expect(metrics.networkShellFallbacksAfterExplore).toBe(0);
+    expect(evaluateVerdict(metrics, 'answer text').verdict).toBe('pass');
+  });
+});

--- a/tests/orchestration/answer-synthesizer.test.ts
+++ b/tests/orchestration/answer-synthesizer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { synthesizeAnswer } from '../../src/orchestration/answer-synthesizer.js';
+import type { ResearchEvidence } from '../../src/orchestration/research-types.js';
+
+const evidence = (sourceKind: ResearchEvidence['sourceKind'], summary: string): ResearchEvidence => ({
+  title: sourceKind,
+  url: `https://example.com/${sourceKind}`,
+  sourceKind,
+  method: 'http',
+  summary,
+  supports: [summary]
+});
+
+describe('synthesizeAnswer', () => {
+  it('uses official evidence as primary findings', () => {
+    expect(
+      synthesizeAnswer({
+        evidence: [
+          evidence('official-docs', 'Set coverage.provider to v8.'),
+          evidence('official-api', 'Install @vitest/coverage-v8.')
+        ],
+        partial: false
+      }).findings
+    ).toEqual(['Set coverage.provider to v8.', 'Install @vitest/coverage-v8.']);
+  });
+
+  it('keeps community evidence as practical context', () => {
+    expect(
+      synthesizeAnswer({
+        evidence: [
+          evidence('official-docs', 'Use channel for branded browsers.'),
+          evidence('community', 'Teams use executablePath for custom corporate builds.')
+        ],
+        partial: false
+      }).findings
+    ).toEqual([
+      'Use channel for branded browsers.',
+      'Community/practical context: Teams use executablePath for custom corporate builds.'
+    ]);
+  });
+
+  it('adds caveat for partial evidence', () => {
+    expect(
+      synthesizeAnswer({ evidence: [evidence('community', 'One source only.')], partial: true }).caveat
+    ).toBe('Evidence is partial, so this answer is based on the strongest source found within the bounded research budget.');
+  });
+});

--- a/tests/orchestration/candidate-selector.test.ts
+++ b/tests/orchestration/candidate-selector.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { selectCandidates } from '../../src/orchestration/candidate-selector.js';
+import type { SearchResult } from '../../src/types.js';
+
+const results: SearchResult[] = [
+  { title: 'Blog', url: 'https://example.com/blog', snippet: 'community' },
+  { title: 'Vitest Coverage', url: 'https://vitest.dev/guide/coverage.html', snippet: 'official docs' },
+  { title: 'npm package', url: 'https://www.npmjs.com/package/@vitest/coverage-v8', snippet: 'package' },
+  { title: 'Vitest Coverage duplicate', url: 'https://vitest.dev/guide/coverage.html', snippet: 'duplicate' }
+];
+
+describe('selectCandidates', () => {
+  it('dedupes urls and prefers official docs', () => {
+    expect(selectCandidates({ results, seenUrls: new Set(), maxCandidates: 3 }).map((item) => item.url)).toEqual([
+      'https://vitest.dev/guide/coverage.html',
+      'https://example.com/blog',
+      'https://www.npmjs.com/package/@vitest/coverage-v8'
+    ]);
+  });
+
+  it('skips already seen urls', () => {
+    expect(
+      selectCandidates({
+        results,
+        seenUrls: new Set(['https://vitest.dev/guide/coverage.html']),
+        maxCandidates: 3
+      }).map((item) => item.url)
+    ).not.toContain('https://vitest.dev/guide/coverage.html');
+  });
+});

--- a/tests/orchestration/evidence-ranker.test.ts
+++ b/tests/orchestration/evidence-ranker.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { rankEvidence } from '../../src/orchestration/evidence-ranker.js';
+import type { ResearchEvidence } from '../../src/orchestration/research-types.js';
+
+const evidence = (sourceKind: ResearchEvidence['sourceKind'], url: string): ResearchEvidence => ({
+  title: url,
+  url,
+  sourceKind,
+  method: 'http',
+  summary: `${sourceKind} summary`,
+  supports: [`${sourceKind} support`]
+});
+
+describe('rankEvidence', () => {
+  it('ranks official sources above community and package pages', () => {
+    const ranked = rankEvidence([
+      evidence('community', 'https://example.com/post'),
+      evidence('package-page', 'https://www.npmjs.com/package/x'),
+      evidence('official-api', 'https://vitest.dev/config/'),
+      evidence('official-docs', 'https://vitest.dev/guide/coverage.html')
+    ]);
+
+    expect(ranked.map((item) => item.sourceKind)).toEqual([
+      'official-docs',
+      'official-api',
+      'community',
+      'package-page'
+    ]);
+  });
+
+  it('dedupes evidence by url', () => {
+    const ranked = rankEvidence([
+      evidence('community', 'https://example.com/post'),
+      evidence('official-docs', 'https://example.com/post')
+    ]);
+
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].sourceKind).toBe('official-docs');
+  });
+});

--- a/tests/orchestration/query-planner.test.ts
+++ b/tests/orchestration/query-planner.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { planSearchQueries } from '../../src/orchestration/query-planner.js';
+
+describe('planSearchQueries', () => {
+  it('returns the original query for the first pass', () => {
+    expect(
+      planSearchQueries({
+        originalQuery: 'Find current Vitest coverage docs for V8 provider',
+        passIndex: 0,
+        previousQueries: [],
+        gaps: []
+      })
+    ).toEqual(['Find current Vitest coverage docs for V8 provider']);
+  });
+
+  it('adds targeted official-docs query on later passes', () => {
+    expect(
+      planSearchQueries({
+        originalQuery: 'Find current Vitest coverage docs for V8 provider',
+        passIndex: 1,
+        previousQueries: ['Find current Vitest coverage docs for V8 provider'],
+        gaps: ['Need official docs or API reference.']
+      })
+    ).toContain('site:vitest.dev Vitest coverage docs V8 provider');
+  });
+
+  it('does not repeat previous queries', () => {
+    expect(
+      planSearchQueries({
+        originalQuery: 'DuckDuckGo HTML scraping Node.js pitfalls',
+        passIndex: 1,
+        previousQueries: [
+          'DuckDuckGo HTML scraping Node.js pitfalls',
+          'site:github.com DuckDuckGo HTML scraping Node.js pitfalls'
+        ],
+        gaps: ['Need implementation references.']
+      })
+    ).not.toContain('site:github.com DuckDuckGo HTML scraping Node.js pitfalls');
+  });
+});

--- a/tests/orchestration/research-orchestrator.test.ts
+++ b/tests/orchestration/research-orchestrator.test.ts
@@ -134,7 +134,64 @@ describe('research orchestrator types', () => {
     expect(result.decision.action).toBe('research-again');
   });
 
-  it('escalates one specific page to headless only when approved by the orchestrator', async () => {
+  it('answers when successful headless content completes the evidence set', async () => {
+    const headlessFetch = vi.fn().mockResolvedValue({
+      status: 'ok',
+      url: 'https://vitest.dev/guide/coverage.html',
+      content: {
+        title: 'Coverage | Guide | Vitest',
+        text: 'Set coverage.provider to v8. Install @vitest/coverage-v8. Run vitest with --coverage.'
+      },
+      metadata: {
+        method: 'headless',
+        cacheHit: false,
+        browser: 'edge',
+        navigationMs: 900,
+        truncated: false
+      }
+    });
+
+    const orchestrator = createResearchOrchestrator({
+      worker: {
+        run: vi.fn().mockResolvedValue({
+          searchQueries: ['vitest coverage'],
+          evidence: [
+            {
+              title: 'vitest/docs/guide/coverage.md',
+              url: 'https://github.com/vitest-dev/vitest/blob/main/docs/guide/coverage.md',
+              sourceKind: 'official-docs',
+              method: 'http',
+              summary: 'Vitest supports native V8 coverage.',
+              supports: ['V8 coverage']
+            }
+          ],
+          gaps: [{ kind: 'fetch-failed', message: 'HTTP fetch was weak for https://vitest.dev/guide/coverage.html' }],
+          lowValueOutcomes: [],
+          suggestedHeadlessUrl: 'https://vitest.dev/guide/coverage.html',
+          exhaustedBudget: false
+        })
+      },
+      headlessFetch
+    });
+
+    const result = await orchestrator.run({ query: 'vitest coverage v8 provider' });
+
+    expect(result.evidence).toEqual([
+      expect.objectContaining({
+        title: 'vitest/docs/guide/coverage.md',
+        method: 'http'
+      }),
+      expect.objectContaining({
+        title: 'Coverage | Guide | Vitest',
+        url: 'https://vitest.dev/guide/coverage.html',
+        sourceKind: 'official-docs',
+        method: 'headless'
+      })
+    ]);
+    expect(result.decision.action).toBe('answer');
+  });
+
+  it('fetches one specific page with headless only when approved by the orchestrator', async () => {
     const headlessFetch = vi.fn().mockResolvedValue({
       status: 'ok',
       url: 'https://example.com/app',
@@ -164,7 +221,8 @@ describe('research orchestrator types', () => {
 
     const result = await orchestrator.run({ query: 'dynamic app' });
 
-    expect(result.decision.action).toBe('escalate-headless');
+    expect(result.decision.action).toBe('research-again');
+    expect(result.evidence).toHaveLength(1);
     expect(headlessFetch).toHaveBeenCalledWith({ url: 'https://example.com/app' });
   });
 

--- a/tests/orchestration/research-orchestrator.test.ts
+++ b/tests/orchestration/research-orchestrator.test.ts
@@ -191,6 +191,43 @@ describe('research orchestrator types', () => {
     expect(result.decision.action).toBe('answer');
   });
 
+  it('does not turn headless bot-check pages into evidence', async () => {
+    const headlessFetch = vi.fn().mockResolvedValue({
+      status: 'ok',
+      url: 'https://medium.com/example',
+      content: {
+        title: 'Performing security verification',
+        text: 'This website uses a security service to protect itself from online attacks. Please verify you are not a bot.'
+      },
+      metadata: {
+        method: 'headless',
+        cacheHit: false,
+        browser: 'edge',
+        navigationMs: 900,
+        truncated: false
+      }
+    });
+
+    const orchestrator = createResearchOrchestrator({
+      worker: {
+        run: vi.fn().mockResolvedValue({
+          searchQueries: ['medium ddg scraping'],
+          evidence: [],
+          gaps: [{ kind: 'fetch-failed', message: 'HTTP fetch was weak for https://medium.com/example' }],
+          lowValueOutcomes: [],
+          suggestedHeadlessUrl: 'https://medium.com/example',
+          exhaustedBudget: false
+        })
+      },
+      headlessFetch
+    });
+
+    const result = await orchestrator.run({ query: 'duckduckgo scraping medium source' });
+
+    expect(result.evidence).toEqual([]);
+    expect(result.decision.action).toBe('escalate-headless');
+  });
+
   it('fetches one specific page with headless only when approved by the orchestrator', async () => {
     const headlessFetch = vi.fn().mockResolvedValue({
       status: 'ok',

--- a/tests/orchestration/research-orchestrator.test.ts
+++ b/tests/orchestration/research-orchestrator.test.ts
@@ -288,6 +288,62 @@ describe('research orchestrator types', () => {
     expect(result.evidence[0]?.sourceKind).not.toBe('package-page');
   });
 
+  it('runs another search pass when first pass evidence is too thin', async () => {
+    const worker = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({
+          searchQueries: ['vitest coverage'],
+          evidence: [
+            {
+              title: 'Blog',
+              url: 'https://example.com/blog',
+              sourceKind: 'community',
+              method: 'http',
+              summary: 'community summary',
+              supports: ['community support']
+            }
+          ],
+          gaps: [{ kind: 'needs-more-evidence', message: 'Need official docs.' }],
+          lowValueOutcomes: [],
+          suggestedHeadlessUrl: undefined,
+          exhaustedBudget: false
+        })
+        .mockResolvedValueOnce({
+          searchQueries: ['site:vitest.dev Vitest coverage docs V8 provider'],
+          evidence: [
+            {
+              title: 'Coverage | Guide | Vitest',
+              url: 'https://vitest.dev/guide/coverage.html',
+              sourceKind: 'official-docs',
+              method: 'http',
+              summary: 'Official coverage docs',
+              supports: ['provider v8']
+            },
+            {
+              title: 'Config | Vitest',
+              url: 'https://vitest.dev/config/',
+              sourceKind: 'official-api',
+              method: 'http',
+              summary: 'Official config docs',
+              supports: ['coverage config']
+            }
+          ],
+          gaps: [],
+          lowValueOutcomes: [],
+          suggestedHeadlessUrl: undefined,
+          exhaustedBudget: false
+        })
+    };
+
+    const orchestrator = createResearchOrchestrator({ worker, headlessFetch: vi.fn() });
+    const result = await orchestrator.run({ query: 'Find Vitest coverage V8 docs' });
+
+    expect(worker.run).toHaveBeenCalledTimes(2);
+    expect(result.decision.action).toBe('answer');
+    expect(result.evidence.map((item) => item.sourceKind)).toEqual(['official-docs', 'official-api', 'community']);
+  });
+
   it('records low-value bot-check outcomes as a reason not to escalate again', async () => {
     const headlessFetch = vi.fn().mockResolvedValue({
       status: 'ok',

--- a/tests/orchestration/stop-decider.test.ts
+++ b/tests/orchestration/stop-decider.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { decideNextResearchStep } from '../../src/orchestration/stop-decider.js';
+import type { ResearchEvidence } from '../../src/orchestration/research-types.js';
+
+const evidence = (sourceKind: ResearchEvidence['sourceKind']): ResearchEvidence => ({
+  title: sourceKind,
+  url: `https://example.com/${sourceKind}`,
+  sourceKind,
+  method: 'http',
+  summary: 'summary',
+  supports: ['support']
+});
+
+describe('decideNextResearchStep', () => {
+  it('answers when enough strong official evidence exists', () => {
+    expect(
+      decideNextResearchStep({
+        evidence: [evidence('official-docs'), evidence('official-api')],
+        suggestedHeadlessUrls: [],
+        passIndex: 0,
+        maxPasses: 3,
+        headlessAttempts: 0,
+        maxHeadlessAttempts: 2
+      }).action
+    ).toBe('answer');
+  });
+
+  it('continues when evidence is thin and budget remains', () => {
+    expect(
+      decideNextResearchStep({
+        evidence: [evidence('community')],
+        suggestedHeadlessUrls: [],
+        passIndex: 0,
+        maxPasses: 3,
+        headlessAttempts: 0,
+        maxHeadlessAttempts: 2
+      }).action
+    ).toBe('search-again');
+  });
+
+  it('escalates a weak high-value page when headless budget remains', () => {
+    expect(
+      decideNextResearchStep({
+        evidence: [],
+        suggestedHeadlessUrls: ['https://vitest.dev/guide/coverage.html'],
+        passIndex: 0,
+        maxPasses: 3,
+        headlessAttempts: 0,
+        maxHeadlessAttempts: 2
+      })
+    ).toEqual({ action: 'headless', url: 'https://vitest.dev/guide/coverage.html' });
+  });
+
+  it('stops with caveat when budget is exhausted', () => {
+    expect(
+      decideNextResearchStep({
+        evidence: [evidence('community')],
+        suggestedHeadlessUrls: [],
+        passIndex: 2,
+        maxPasses: 3,
+        headlessAttempts: 2,
+        maxHeadlessAttempts: 2
+      }).action
+    ).toBe('answer-with-caveat');
+  });
+});

--- a/tests/presentation/explore-presentation.test.ts
+++ b/tests/presentation/explore-presentation.test.ts
@@ -7,15 +7,25 @@ describe('buildExplorePresentation', () => {
       status: 'ok',
       findings: ['Use channel', 'Treat executablePath as fallback'],
       sources: [
-        { title: 'Browsers | Playwright', url: 'https://playwright.dev/docs/browsers' },
-        { title: 'BrowserType | Playwright', url: 'https://playwright.dev/docs/api/class-browsertype' }
+        { title: 'Browsers | Playwright', url: 'https://playwright.dev/docs/browsers', method: 'http' },
+        { title: 'BrowserType | Playwright', url: 'https://playwright.dev/docs/api/class-browsertype', method: 'headless' }
       ],
-      caveat: undefined
+      caveat: undefined,
+      metadata: {
+        searchPasses: 2,
+        fetchedPages: 5,
+        headlessAttempts: 1,
+        exhaustedBudget: false
+      }
     });
 
     expect(presentation.views.compact).toBe('Reviewed 2 sources · synthesized answer with 2 findings');
-    expect(presentation.views.preview).toContain('- Use channel');
+    expect(presentation.views.preview).toContain('- [web_fetch] Use channel');
+    expect(presentation.views.preview).toContain('- [web_fetch_headless] Treat executablePath as fallback');
+    expect(presentation.views.preview).toContain('Internal research: web_search ×2');
     expect(presentation.views.verbose).toContain('Sources');
+    expect(presentation.views.verbose).toContain('- [web_fetch_headless] BrowserType | Playwright: https://playwright.dev/docs/api/class-browsertype');
+    expect(presentation.views.verbose).toContain('Internal tools');
   });
 
   it('keeps invalid-query errors concise', () => {

--- a/tests/presentation/explore-presentation.test.ts
+++ b/tests/presentation/explore-presentation.test.ts
@@ -28,6 +28,24 @@ describe('buildExplorePresentation', () => {
     expect(presentation.views.verbose).toContain('Internal tools');
   });
 
+  it('says when no usable evidence was found in preview and verbose views', () => {
+    const presentation = buildExplorePresentation({
+      status: 'ok',
+      findings: [],
+      sources: [],
+      metadata: {
+        searchPasses: 2,
+        fetchedPages: 4,
+        headlessAttempts: 0,
+        exhaustedBudget: true
+      }
+    });
+
+    expect(presentation.views.compact).toBe('No usable evidence found');
+    expect(presentation.views.preview).toContain('No usable evidence found.');
+    expect(presentation.views.verbose).toContain('No usable evidence found.');
+  });
+
   it('keeps invalid-query errors concise', () => {
     const presentation = buildExplorePresentation({
       status: 'error',

--- a/tests/tools/web-explore.test.ts
+++ b/tests/tools/web-explore.test.ts
@@ -62,8 +62,8 @@ describe('web_explore tool', () => {
 
     expect(result.status).toBe('ok');
     expect(result.findings).toEqual([
-      'Use channel for branded Chrome or Edge when possible.',
-      'Treat executablePath as a fallback because Playwright documents it as use-at-your-own-risk.'
+      'Use channel for branded browsers.',
+      'executablePath is supported but use at your own risk.'
     ]);
     expect(result.sources).toEqual([
       {
@@ -79,9 +79,7 @@ describe('web_explore tool', () => {
     expect(result.presentation?.views.compact).toBe(
       'Reviewed 2 sources · synthesized answer with 2 findings'
     );
-    expect(result.presentation?.views.preview).toContain(
-      'Use channel for branded Chrome or Edge when possible.'
-    );
+    expect(result.presentation?.views.preview).toContain('Use channel for branded browsers.');
     expect(result).not.toHaveProperty('text');
   });
 
@@ -120,7 +118,7 @@ describe('web_explore tool', () => {
 
     expect(result.status).toBe('ok');
     expect(result.findings).toEqual([
-      'Vitest coverage docs say to set coverage.provider to v8 and install @vitest/coverage-v8.'
+      'Set coverage.provider to v8 and install @vitest/coverage-v8.'
     ]);
     expect(result.sources).toEqual([
       {
@@ -128,7 +126,7 @@ describe('web_explore tool', () => {
         url: 'https://vitest.dev/guide/coverage.html'
       }
     ]);
-    expect(result.caveat).toBe('Evidence is partial, so this answer is based on the strongest source found so far.');
+    expect(result.caveat).toBe('Evidence is partial, so this answer is based on the strongest source found within the bounded research budget.');
     expect(result.presentation?.views.compact).toBe(
       'Reviewed 1 sources · synthesized answer with 1 findings'
     );
@@ -179,7 +177,7 @@ describe('web_explore tool', () => {
     expect(JSON.stringify(result)).not.toContain('searchQueries');
     expect(JSON.stringify(result)).not.toContain('lowValueOutcomes');
     expect(JSON.stringify(result)).not.toContain('suggestedHeadlessUrl');
-    expect(result.findings).toEqual(['A concise summary.']);
-    expect(result.presentation?.views.preview).toContain('- A concise summary.');
+    expect(result.findings).toEqual(['Community/practical context: A concise summary.']);
+    expect(result.presentation?.views.preview).toContain('- Community/practical context: A concise summary.');
   });
 });

--- a/tests/tools/web-explore.test.ts
+++ b/tests/tools/web-explore.test.ts
@@ -68,11 +68,13 @@ describe('web_explore tool', () => {
     expect(result.sources).toEqual([
       {
         title: 'Browsers | Playwright',
-        url: 'https://playwright.dev/docs/browsers'
+        url: 'https://playwright.dev/docs/browsers',
+        method: 'http'
       },
       {
         title: 'BrowserType | Playwright',
-        url: 'https://playwright.dev/docs/api/class-browsertype'
+        url: 'https://playwright.dev/docs/api/class-browsertype',
+        method: 'http'
       }
     ]);
     expect(result.caveat).toBeUndefined();
@@ -123,7 +125,8 @@ describe('web_explore tool', () => {
     expect(result.sources).toEqual([
       {
         title: 'Coverage | Guide | Vitest',
-        url: 'https://vitest.dev/guide/coverage.html'
+        url: 'https://vitest.dev/guide/coverage.html',
+        method: 'headless'
       }
     ]);
     expect(result.caveat).toBe('Evidence is partial, so this answer is based on the strongest source found within the bounded research budget.');
@@ -178,6 +181,6 @@ describe('web_explore tool', () => {
     expect(JSON.stringify(result)).not.toContain('lowValueOutcomes');
     expect(JSON.stringify(result)).not.toContain('suggestedHeadlessUrl');
     expect(result.findings).toEqual(['Community/practical context: A concise summary.']);
-    expect(result.presentation?.views.preview).toContain('- Community/practical context: A concise summary.');
+    expect(result.presentation?.views.preview).toContain('- [web_fetch] Community/practical context: A concise summary.');
   });
 });


### PR DESCRIPTION
This makes web_explore the only public web research tool and moves search/fetch/headless orchestration behind it. Also cleaned up the config/docs around that, tightened the live eval so shell network fallbacks after web_explore get caught, and fixed the CI Rollup optional-dep issue so Actions can build straight from npm ci.

Checked with npm run lint, npm run build, npm test, npm run docs:build, npm run eval:live, and npm run release:dry-run.
