### PR TITLE
feat: add Tavily as configurable search backend alongside DuckDuckGo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
+        "@tavily/core": "^0.6.0",
         "cheerio": "^1.1.0",
         "jsdom": "^26.0.0",
         "playwright-core": "^1.54.0"
@@ -2701,6 +2702,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@tavily/core": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@tavily/core/-/core-0.6.4.tgz",
+      "integrity": "sha512-PppC0p2SwkoImLiYFT/uqDyWKPivpVsIM16HUf1Apmtbqg1YhI7Yg5Hq6eYSojC6COVCGXE4CotBnWqUmrai+A==",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "https-proxy-agent": "^7.0.6",
+        "js-tiktoken": "^1.0.14"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "dev": true,
@@ -3407,6 +3418,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "dev": true,
@@ -3417,7 +3451,6 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3499,6 +3532,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ccount": {
@@ -3704,6 +3749,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3845,6 +3901,14 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3924,6 +3988,19 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "dev": true,
@@ -3978,10 +4055,51 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4244,6 +4362,25 @@
         "tabbable": "^6.4.0"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "dev": true,
@@ -4270,6 +4407,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "dev": true,
@@ -4294,6 +4465,14 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gaxios": {
@@ -4339,6 +4518,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4416,6 +4630,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -4427,6 +4652,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -4711,6 +4972,14 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "dev": true,
@@ -4869,6 +5138,14 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-to-hast": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@mozilla/readability": "^0.6.0",
+    "@tavily/core": "^0.6.0",
     "cheerio": "^1.1.0",
     "jsdom": "^26.0.0",
     "playwright-core": "^1.54.0"

--- a/src/search/tavily.ts
+++ b/src/search/tavily.ts
@@ -1,0 +1,24 @@
+import { tavily } from '@tavily/core';
+import type { SearchResult } from '../types.js';
+
+export async function fetchTavilyResults(
+  query: string,
+  apiKey?: string
+): Promise<SearchResult[]> {
+  const key = apiKey ?? process.env.TAVILY_API_KEY;
+  if (!key) {
+    throw new Error('TAVILY_API_KEY is not set.');
+  }
+
+  const client = tavily({ apiKey: key });
+  const response = await client.search(query, {
+    maxResults: 10,
+    searchDepth: 'basic'
+  });
+
+  return response.results.map((r: { title: string; url: string; content: string }) => ({
+    title: r.title ?? '',
+    url: r.url ?? '',
+    snippet: r.content ?? ''
+  }));
+}

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,7 +1,10 @@
 import { createCacheKey, createTtlCache } from '../cache/ttl-cache.js';
 import { buildSearchPresentation } from '../presentation/search-presentation.js';
 import { fetchDuckDuckGoHtml, parseDuckDuckGoResults } from '../search/duckduckgo.js';
+import { fetchTavilyResults } from '../search/tavily.js';
 import type { WebSearchResponse } from '../types.js';
+
+export type SearchBackend = 'duckduckgo' | 'tavily' | 'auto';
 
 function classifySearchFailure(error: unknown) {
   const rawMessage = error instanceof Error ? error.message : 'Unknown search failure.';
@@ -40,15 +43,111 @@ function htmlLooksBlocked(html: string) {
   );
 }
 
+async function searchWithDuckDuckGo(
+  query: string,
+  searchHtml: (query: string) => Promise<string>
+): Promise<WebSearchResponse> {
+  try {
+    const html = await searchHtml(query);
+    const parsed = parseDuckDuckGoResults(html);
+
+    if (parsed.results.length > 0) {
+      return {
+        status: 'ok',
+        results: parsed.results,
+        metadata: { backend: 'duckduckgo', cacheHit: false }
+      };
+    }
+
+    if (parsed.noResults) {
+      return {
+        status: 'error',
+        results: [],
+        metadata: { backend: 'duckduckgo', cacheHit: false },
+        error: {
+          code: 'NO_RESULTS',
+          message: 'DuckDuckGo returned no usable results for this query.'
+        }
+      };
+    }
+
+    if (htmlLooksBlocked(html)) {
+      return {
+        status: 'error',
+        results: [],
+        metadata: { backend: 'duckduckgo', cacheHit: false },
+        error: {
+          code: 'BLOCKED',
+          message: 'DuckDuckGo search appears to be blocked or rate limited.'
+        }
+      };
+    }
+
+    return {
+      status: 'error',
+      results: [],
+      metadata: { backend: 'duckduckgo', cacheHit: false },
+      error: {
+        code: 'PARSE_FAILED',
+        message: 'DuckDuckGo returned a page, but it did not match the expected results format.'
+      }
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      results: [],
+      metadata: { backend: 'duckduckgo', cacheHit: false },
+      error: classifySearchFailure(error)
+    };
+  }
+}
+
+async function searchWithTavily(
+  query: string,
+  cache: { get(key: string): WebSearchResponse | undefined; set(key: string, value: WebSearchResponse): void },
+  cacheKey: string
+): Promise<WebSearchResponse> {
+  try {
+    const results = await fetchTavilyResults(query);
+    if (results.length === 0) {
+      const result: WebSearchResponse = {
+        status: 'error',
+        results: [],
+        metadata: { backend: 'tavily', cacheHit: false },
+        error: { code: 'NO_RESULTS', message: 'Tavily returned no results for this query.' }
+      };
+      return { ...result, presentation: buildSearchPresentation(result) };
+    }
+    const result: WebSearchResponse = {
+      status: 'ok',
+      results,
+      metadata: { backend: 'tavily', cacheHit: false }
+    };
+    cache.set(cacheKey, result);
+    return { ...result, presentation: buildSearchPresentation(result) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown Tavily search failure.';
+    const result: WebSearchResponse = {
+      status: 'error',
+      results: [],
+      metadata: { backend: 'tavily', cacheHit: false },
+      error: { code: 'FETCH_FAILED', message: `Tavily search failed: ${message}` }
+    };
+    return { ...result, presentation: buildSearchPresentation(result) };
+  }
+}
+
 export function createWebSearchTool({
   searchHtml = fetchDuckDuckGoHtml,
-  cache = createTtlCache<WebSearchResponse>({ ttlMs: 30_000 })
+  cache = createTtlCache<WebSearchResponse>({ ttlMs: 30_000 }),
+  backend = 'auto'
 }: {
   searchHtml?: (query: string) => Promise<string>;
   cache?: {
     get(key: string): WebSearchResponse | undefined;
     set(key: string, value: WebSearchResponse): void;
   };
+  backend?: SearchBackend;
 } = {}) {
   return async function webSearch({ query }: { query: string }): Promise<WebSearchResponse> {
     const normalizedQuery = query.trim();
@@ -79,79 +178,27 @@ export function createWebSearchTool({
       };
     }
 
-    try {
-      const html = await searchHtml(normalizedQuery);
-      const parsed = parseDuckDuckGoResults(html);
-
-      if (parsed.results.length > 0) {
-        const result: WebSearchResponse = {
-          status: 'ok',
-          results: parsed.results,
-          metadata: { backend: 'duckduckgo', cacheHit: false }
-        };
-        cache.set(cacheKey, result);
-        return {
-          ...result,
-          presentation: buildSearchPresentation(result)
-        };
-      }
-
-      if (parsed.noResults) {
-        const result: WebSearchResponse = {
-          status: 'error',
-          results: [],
-          metadata: { backend: 'duckduckgo', cacheHit: false },
-          error: {
-            code: 'NO_RESULTS',
-            message: 'DuckDuckGo returned no usable results for this query.'
-          }
-        };
-        return {
-          ...result,
-          presentation: buildSearchPresentation(result)
-        };
-      }
-
-      if (htmlLooksBlocked(html)) {
-        const result: WebSearchResponse = {
-          status: 'error',
-          results: [],
-          metadata: { backend: 'duckduckgo', cacheHit: false },
-          error: {
-            code: 'BLOCKED',
-            message: 'DuckDuckGo search appears to be blocked or rate limited.'
-          }
-        };
-        return {
-          ...result,
-          presentation: buildSearchPresentation(result)
-        };
-      }
-
-      const result: WebSearchResponse = {
-        status: 'error',
-        results: [],
-        metadata: { backend: 'duckduckgo', cacheHit: false },
-        error: {
-          code: 'PARSE_FAILED',
-          message: 'DuckDuckGo returned a page, but it did not match the expected results format.'
-        }
-      };
-      return {
-        ...result,
-        presentation: buildSearchPresentation(result)
-      };
-    } catch (error) {
-      const result: WebSearchResponse = {
-        status: 'error',
-        results: [],
-        metadata: { backend: 'duckduckgo', cacheHit: false },
-        error: classifySearchFailure(error)
-      };
-      return {
-        ...result,
-        presentation: buildSearchPresentation(result)
-      };
+    if (backend === 'tavily') {
+      return searchWithTavily(normalizedQuery, cache, cacheKey);
     }
+
+    const ddgResult = await searchWithDuckDuckGo(normalizedQuery, searchHtml);
+
+    if (ddgResult.status === 'ok') {
+      cache.set(cacheKey, ddgResult);
+      return { ...ddgResult, presentation: buildSearchPresentation(ddgResult) };
+    }
+
+    const shouldFallback =
+      backend === 'auto' &&
+      ddgResult.error &&
+      (ddgResult.error.code === 'BLOCKED' || ddgResult.error.code === 'PARSE_FAILED') &&
+      !!process.env.TAVILY_API_KEY;
+
+    if (shouldFallback) {
+      return searchWithTavily(normalizedQuery, cache, cacheKey);
+    }
+
+    return { ...ddgResult, presentation: buildSearchPresentation(ddgResult) }
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type ToolError = {
 };
 
 export type SearchMetadata = {
-  backend: 'duckduckgo';
+  backend: 'duckduckgo' | 'tavily';
   cacheHit: boolean;
 };
 


### PR DESCRIPTION
## Summary

Adds Tavily as a parallel/fallback search backend alongside the existing DuckDuckGo HTML scraping approach. DuckDuckGo scraping is prone to blocks and CAPTCHAs; Tavily provides a reliable API-backed alternative.

### What changed
- **New file `src/search/tavily.ts`**: Wraps the `@tavily/core` SDK `search()` call, mapping results to the shared `SearchResult[]` type.
- **`src/types.ts`**: Extended `SearchMetadata.backend` union from `'duckduckgo'` to `'duckduckgo' | 'tavily'`.
- **`src/tools/web-search.ts`**: Added `backend` option (`'duckduckgo' | 'tavily' | 'auto'`, default `'auto'`) to `createWebSearchTool`. In `'auto'` mode, DuckDuckGo is attempted first; on `BLOCKED` or `PARSE_FAILED` errors, Tavily is used as fallback when `TAVILY_API_KEY` is available. Extracted `searchWithDuckDuckGo` and `searchWithTavily` helper functions.
- **`package.json`**: Added `@tavily/core` as a production dependency.

### Files changed
- `src/search/tavily.ts` (new)
- `src/types.ts`
- `src/tools/web-search.ts`
- `package.json`

### Dependency changes
- Added `@tavily/core ^0.6.0` to production dependencies

### Environment variable changes
- `TAVILY_API_KEY`: Required when using `backend: 'tavily'`; optional in `'auto'` mode (DuckDuckGo remains the default, Tavily used as fallback only when the key is present)

### Notes for reviewers
- No breaking changes — existing callers using default options get the same DuckDuckGo-first behavior with automatic Tavily fallback when `TAVILY_API_KEY` is set.
- The `SearchBackend` type is exported for consumers who want to explicitly select a backend.
- TypeScript compilation passes cleanly with `tsc --noEmit`.


### Automated Review

- Passed after 1 attempt(s)
- Final review: The implementation correctly adds Tavily as a configurable/fallback search backend alongside DuckDuckGo. All four files listed in the plan are addressed: `src/search/tavily.ts` (new), `src/types.ts`, `src/tools/web-search.ts`, and `package.json`/`package-lock.json`. The Tavily SDK usage is correct, the `auto` fallback logic is sound, no breaking changes are introduced, and existing tests remain valid. There are a few minor issues (hardcoded backend in invalid-query error, missing tests for new paths, no README env-var docs) but none rise to major or critical severity.
