### PR TITLE
Add configurable web backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ The format is intentionally simple and release-oriented.
 ## Unreleased
 
 ### Added
-- Nothing yet.
+- Added configurable web backends for `web_explore`, including SearXNG search and Firecrawl fetch support.
+- Added backend diagnostics to `/web-agent doctor`, including config validation and self-hosted endpoint checks.
+- Added dedicated self-hosted backend docs for connecting existing SearXNG and Firecrawl services.
 
 ### Changed
-- Nothing yet.
+- `/web-agent show` now includes the effective backend configuration.
+- `web_explore` now loads the effective backend config while preserving the default DuckDuckGo, HTTP, and local-browser behavior.
 
 ### Fixed
-- Nothing yet.
+- Fixed backend config merging so provider-specific fields do not leak when a higher-precedence config changes providers.
+- Kept the configured `web_explore` workflow reusable while backend config is unchanged, avoiding unnecessary backend/cache recreation.
 
 ### Breaking
 - None.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Self-hosted example for existing SearXNG/Firecrawl services:
 
 Prefer `PI_WEB_AGENT_FIRECRAWL_API_KEY` for Firecrawl auth instead of putting secrets in project config. `/web-agent doctor` validates required backend fields and checks configured self-hosted endpoints.
 
+Full guide: https://demigodmode.github.io/pi-web-agent/self-hosted-backends
+
 ## Local development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Backend config is also supported. Defaults are DuckDuckGo search, plain HTTP fet
 }
 ```
 
-Self-hosted example:
+Self-hosted example for existing SearXNG/Firecrawl services:
 
 ```json
 {
@@ -129,6 +129,8 @@ Self-hosted example:
   }
 }
 ```
+
+Prefer `PI_WEB_AGENT_FIRECRAWL_API_KEY` for Firecrawl auth instead of putting secrets in project config. `/web-agent doctor` validates required backend fields and checks configured self-hosted endpoints.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ Example:
 }
 ```
 
+Backend config is also supported. Defaults are DuckDuckGo search, plain HTTP fetch, and local browser headless fallback:
+
+```json
+{
+  "backends": {
+    "search": { "provider": "duckduckgo" },
+    "fetch": { "provider": "http" },
+    "headless": { "provider": "local-browser" }
+  }
+}
+```
+
+Self-hosted example:
+
+```json
+{
+  "backends": {
+    "search": { "provider": "searxng", "baseUrl": "http://localhost:8080" },
+    "fetch": { "provider": "firecrawl", "baseUrl": "http://localhost:3002" },
+    "headless": { "provider": "local-browser" }
+  }
+}
+```
+
 ## Local development
 
 ```bash

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,6 +10,7 @@ export default defineConfig({
       { text: 'Getting started', link: '/getting-started' },
       { text: 'Tools', link: '/tools' },
       { text: 'Presentation', link: '/presentation' },
+      { text: 'Self-hosted', link: '/self-hosted-backends' },
       { text: 'Development', link: '/development' },
       { text: 'GitHub', link: 'https://github.com/demigodmode/pi-web-agent' }
     ],
@@ -22,6 +23,7 @@ export default defineConfig({
           { text: 'Install', link: '/install' },
           { text: 'Presentation and settings', link: '/presentation' },
           { text: 'Setup modes', link: '/setup-modes' },
+          { text: 'Self-hosted backends', link: '/self-hosted-backends' },
           { text: 'Tools', link: '/tools' },
           { text: 'Architecture', link: '/architecture' },
           { text: 'Development', link: '/development' },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,24 @@ From there you can open settings, show config, run doctor, or reset config. Sett
 
 If you want the full details, see [Presentation and settings](/presentation).
 
+## Optional self-hosted backends
+
+By default, `web_explore` uses DuckDuckGo HTML search, plain HTTP page reads, and local browser fallback when needed.
+
+If you run your own services, you can point search at SearXNG and page reading at Firecrawl by editing either config file:
+
+```json
+{
+  "backends": {
+    "search": { "provider": "searxng", "baseUrl": "http://localhost:8080" },
+    "fetch": { "provider": "firecrawl", "baseUrl": "http://localhost:3002" },
+    "headless": { "provider": "local-browser" }
+  }
+}
+```
+
+Use `/web-agent show` to confirm the effective backend config.
+
 ## Browser rendering requirement
 
 Headless rendering currently requires a detectable Chromium-family browser: Chrome, Chromium, Edge, or Brave.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,6 +72,8 @@ If you run your own services, you can point search at SearXNG and page reading a
 
 Use `/web-agent show` to confirm the effective backend config. Use `/web-agent doctor` to check whether configured self-hosted endpoints respond.
 
+For the full setup guide, see [Self-hosted backends](/self-hosted-backends).
+
 If your Firecrawl instance requires an API key, prefer an environment variable instead of committing secrets into project config:
 
 ```text

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,17 @@ If you run your own services, you can point search at SearXNG and page reading a
 }
 ```
 
-Use `/web-agent show` to confirm the effective backend config.
+Use `/web-agent show` to confirm the effective backend config. Use `/web-agent doctor` to check whether configured self-hosted endpoints respond.
+
+If your Firecrawl instance requires an API key, prefer an environment variable instead of committing secrets into project config:
+
+```text
+PI_WEB_AGENT_FIRECRAWL_API_KEY=...
+```
+
+You can still set `backends.fetch.apiKey` in config for local-only setups.
+
+This project only connects to existing SearXNG/Firecrawl services; it does not manage or document how to run those services.
 
 ## Browser rendering requirement
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,6 +57,34 @@ Project config overrides global config.
 
 If you change settings through `/web-agent`, those files are what get updated.
 
+## Backend config
+
+The default backend setup is:
+
+```json
+{
+  "backends": {
+    "search": { "provider": "duckduckgo" },
+    "fetch": { "provider": "http" },
+    "headless": { "provider": "local-browser" }
+  }
+}
+```
+
+For a self-hosted setup, run SearXNG and Firecrawl yourself and add:
+
+```json
+{
+  "backends": {
+    "search": { "provider": "searxng", "baseUrl": "http://localhost:8080" },
+    "fetch": { "provider": "firecrawl", "baseUrl": "http://localhost:3002" },
+    "headless": { "provider": "local-browser" }
+  }
+}
+```
+
+If your Firecrawl instance requires a key, add `"apiKey": "..."` to the `fetch` config.
+
 ## Watch out for mixed setups
 
 If you have both the npm-installed package and the local repo-based extension in play, it gets easy to think you are testing one copy when Pi is actually loading the other.

--- a/docs/install.md
+++ b/docs/install.md
@@ -93,6 +93,8 @@ For local-only configs you can also add `"apiKey": "..."` to the `fetch` config.
 
 Run `/web-agent doctor` after changing backend config. It validates required `baseUrl` values and checks configured SearXNG/Firecrawl endpoints with a short timeout.
 
+For the full guide, see [Self-hosted backends](/self-hosted-backends).
+
 This package integrates with existing self-hosted services. SearXNG/Firecrawl installation, Docker Compose files, reverse proxies, TLS, and auth setup belong to those projects' docs.
 
 ## Watch out for mixed setups

--- a/docs/install.md
+++ b/docs/install.md
@@ -83,7 +83,17 @@ For a self-hosted setup, run SearXNG and Firecrawl yourself and add:
 }
 ```
 
-If your Firecrawl instance requires a key, add `"apiKey": "..."` to the `fetch` config.
+If your Firecrawl instance requires a key, prefer an environment variable:
+
+```text
+PI_WEB_AGENT_FIRECRAWL_API_KEY=...
+```
+
+For local-only configs you can also add `"apiKey": "..."` to the `fetch` config.
+
+Run `/web-agent doctor` after changing backend config. It validates required `baseUrl` values and checks configured SearXNG/Firecrawl endpoints with a short timeout.
+
+This package integrates with existing self-hosted services. SearXNG/Firecrawl installation, Docker Compose files, reverse proxies, TLS, and auth setup belong to those projects' docs.
 
 ## Watch out for mixed setups
 

--- a/docs/self-hosted-backends.md
+++ b/docs/self-hosted-backends.md
@@ -1,0 +1,233 @@
+# Self-hosted backends
+
+`pi-web-agent` can use existing self-hosted services for search and page reading:
+
+- SearXNG for search
+- Firecrawl for page fetch/extraction
+
+This keeps the public Pi tool the same: the model still calls `web_explore`. The backend config only changes what `web_explore` uses internally.
+
+## What this page does not cover
+
+This project does not manage SearXNG or Firecrawl deployments.
+
+Use the upstream docs for:
+
+- installing either service
+- Docker Compose files
+- reverse proxies
+- TLS
+- auth setup
+- service upgrades
+
+The assumption here is that you already have working services and just want `pi-web-agent` to connect to them.
+
+## Default backend config
+
+Without any backend config, `pi-web-agent` uses:
+
+```json
+{
+  "backends": {
+    "search": { "provider": "duckduckgo" },
+    "fetch": { "provider": "http" },
+    "headless": { "provider": "local-browser" }
+  }
+}
+```
+
+That path does not require SearXNG or Firecrawl.
+
+## Config file locations
+
+Global config:
+
+```text
+~/.pi/agent/extensions/pi-web-agent/config.json
+```
+
+Project config:
+
+```text
+.pi/extensions/pi-web-agent/config.json
+```
+
+Project config overrides global config.
+
+## SearXNG search
+
+To use SearXNG for search, set `backends.search.provider` to `searxng` and provide `baseUrl`:
+
+```json
+{
+  "backends": {
+    "search": {
+      "provider": "searxng",
+      "baseUrl": "http://localhost:8080"
+    }
+  }
+}
+```
+
+`pi-web-agent` expects SearXNG JSON search to work at:
+
+```text
+/search?q=example&format=json
+```
+
+Run this after editing config:
+
+```text
+/web-agent doctor
+```
+
+Doctor checks that the configured SearXNG endpoint responds with JSON that looks like search results.
+
+## Firecrawl fetch
+
+To use Firecrawl for page reading, set `backends.fetch.provider` to `firecrawl` and provide `baseUrl`:
+
+```json
+{
+  "backends": {
+    "fetch": {
+      "provider": "firecrawl",
+      "baseUrl": "http://localhost:3002"
+    }
+  }
+}
+```
+
+`pi-web-agent` calls Firecrawl's scrape endpoint:
+
+```text
+/v1/scrape
+```
+
+If your Firecrawl instance requires an API key, prefer an environment variable:
+
+```text
+PI_WEB_AGENT_FIRECRAWL_API_KEY=...
+```
+
+You can also set an API key in config for local-only setups:
+
+```json
+{
+  "backends": {
+    "fetch": {
+      "provider": "firecrawl",
+      "baseUrl": "http://localhost:3002",
+      "apiKey": "..."
+    }
+  }
+}
+```
+
+Avoid committing project config files that contain secrets.
+
+## Full self-hosted example
+
+```json
+{
+  "backends": {
+    "search": {
+      "provider": "searxng",
+      "baseUrl": "http://localhost:8080"
+    },
+    "fetch": {
+      "provider": "firecrawl",
+      "baseUrl": "http://localhost:3002"
+    },
+    "headless": {
+      "provider": "local-browser"
+    }
+  }
+}
+```
+
+You can combine this with presentation settings in the same file:
+
+```json
+{
+  "presentation": {
+    "defaultMode": "preview"
+  },
+  "backends": {
+    "search": {
+      "provider": "searxng",
+      "baseUrl": "http://localhost:8080"
+    },
+    "fetch": {
+      "provider": "firecrawl",
+      "baseUrl": "http://localhost:3002"
+    },
+    "headless": {
+      "provider": "local-browser"
+    }
+  }
+}
+```
+
+## Verify the setup
+
+Show the effective config:
+
+```text
+/web-agent show
+```
+
+Run diagnostics:
+
+```text
+/web-agent doctor
+```
+
+Expected healthy output includes lines like:
+
+```text
+search: searxng (http://localhost:8080)
+fetch: firecrawl (http://localhost:3002)
+backend config: ok
+search backend: searxng ok
+fetch backend: firecrawl ok
+```
+
+Then try a normal research prompt:
+
+```text
+Find current docs for configuring Vitest coverage with the v8 provider.
+```
+
+The model should still use `web_explore`; it should not need separate SearXNG or Firecrawl tool calls.
+
+## Troubleshooting
+
+### `search provider searxng requires backends.search.baseUrl`
+
+You set `provider` to `searxng` but did not include `baseUrl`.
+
+### `fetch provider firecrawl requires backends.fetch.baseUrl`
+
+You set `provider` to `firecrawl` but did not include `baseUrl`.
+
+### `search backend: searxng warning`
+
+Check that:
+
+- SearXNG is running
+- the configured URL is reachable from the Pi process
+- JSON output works with `format=json`
+
+### `fetch backend: firecrawl warning`
+
+Check that:
+
+- Firecrawl is running
+- `/v1/scrape` is available
+- the API key is set if your instance requires auth
+- the Pi process can reach the configured URL
+
+### Self-hosted privacy expectations
+
+`pi-web-agent` does not silently fall back from SearXNG to DuckDuckGo or from Firecrawl to plain HTTP when you choose self-hosted providers. Fallback policy needs to be explicit because some users choose self-hosted backends specifically to avoid external services.

--- a/docs/setup-modes.md
+++ b/docs/setup-modes.md
@@ -22,8 +22,6 @@ If you are evaluating the package early, check the issue tracker before assuming
 
 ## Self-hosted setups
 
-The same goes for self-hosted search backends like SearXNG.
+If you already run SearXNG or Firecrawl, `pi-web-agent` can connect to them through backend config.
 
-Those are a real direction for the project, but not something the current default package just turns on out of the box.
-
-It is better to say that plainly now than to make the docs sound more finished than the project actually is.
+See [Self-hosted backends](/self-hosted-backends) for the config shape, verification steps, and troubleshooting notes.

--- a/src/backends/config.ts
+++ b/src/backends/config.ts
@@ -1,5 +1,5 @@
-export type SearchBackendConfig = { provider: 'duckduckgo' };
-export type FetchBackendConfig = { provider: 'http' };
+export type SearchBackendConfig = { provider: 'duckduckgo' | 'searxng'; baseUrl?: string };
+export type FetchBackendConfig = { provider: 'http' | 'firecrawl'; baseUrl?: string; apiKey?: string };
 export type HeadlessBackendConfig = { provider: 'local-browser' };
 
 export type BackendConfig = {
@@ -16,8 +16,8 @@ export type BackendConfigOverride = {
 
 export type BackendConfigFile = {
   backends?: {
-    search?: { provider?: unknown };
-    fetch?: { provider?: unknown };
+    search?: { provider?: unknown; baseUrl?: unknown };
+    fetch?: { provider?: unknown; baseUrl?: unknown; apiKey?: unknown };
     headless?: { provider?: unknown };
   };
 };
@@ -34,12 +34,21 @@ export function extractBackendConfigOverride(
   const backends = file?.backends;
   const override: BackendConfigOverride = {};
 
-  if (backends?.search?.provider === 'duckduckgo') {
-    override.search = { provider: 'duckduckgo' };
+  if (backends?.search?.provider === 'duckduckgo' || backends?.search?.provider === 'searxng') {
+    override.search = { provider: backends.search.provider };
+    if (typeof backends.search.baseUrl === 'string') {
+      override.search.baseUrl = backends.search.baseUrl;
+    }
   }
 
-  if (backends?.fetch?.provider === 'http') {
-    override.fetch = { provider: 'http' };
+  if (backends?.fetch?.provider === 'http' || backends?.fetch?.provider === 'firecrawl') {
+    override.fetch = { provider: backends.fetch.provider };
+    if (typeof backends.fetch.baseUrl === 'string') {
+      override.fetch.baseUrl = backends.fetch.baseUrl;
+    }
+    if (typeof backends.fetch.apiKey === 'string') {
+      override.fetch.apiKey = backends.fetch.apiKey;
+    }
   }
 
   if (backends?.headless?.provider === 'local-browser') {

--- a/src/backends/config.ts
+++ b/src/backends/config.ts
@@ -1,0 +1,63 @@
+export type SearchBackendConfig = { provider: 'duckduckgo' };
+export type FetchBackendConfig = { provider: 'http' };
+export type HeadlessBackendConfig = { provider: 'local-browser' };
+
+export type BackendConfig = {
+  search: SearchBackendConfig;
+  fetch: FetchBackendConfig;
+  headless: HeadlessBackendConfig;
+};
+
+export type BackendConfigOverride = {
+  search?: Partial<SearchBackendConfig>;
+  fetch?: Partial<FetchBackendConfig>;
+  headless?: Partial<HeadlessBackendConfig>;
+};
+
+export type BackendConfigFile = {
+  backends?: {
+    search?: { provider?: unknown };
+    fetch?: { provider?: unknown };
+    headless?: { provider?: unknown };
+  };
+};
+
+export const DEFAULT_BACKEND_CONFIG: BackendConfig = {
+  search: { provider: 'duckduckgo' },
+  fetch: { provider: 'http' },
+  headless: { provider: 'local-browser' }
+};
+
+export function extractBackendConfigOverride(
+  file: BackendConfigFile | null | undefined
+): BackendConfigOverride {
+  const backends = file?.backends;
+  const override: BackendConfigOverride = {};
+
+  if (backends?.search?.provider === 'duckduckgo') {
+    override.search = { provider: 'duckduckgo' };
+  }
+
+  if (backends?.fetch?.provider === 'http') {
+    override.fetch = { provider: 'http' };
+  }
+
+  if (backends?.headless?.provider === 'local-browser') {
+    override.headless = { provider: 'local-browser' };
+  }
+
+  return override;
+}
+
+export function mergeBackendConfigLayers(
+  ...layers: Array<BackendConfig | BackendConfigOverride | undefined>
+): BackendConfig {
+  return layers.reduce<BackendConfig>(
+    (merged, layer) => ({
+      search: { ...merged.search, ...layer?.search },
+      fetch: { ...merged.fetch, ...layer?.fetch },
+      headless: { ...merged.headless, ...layer?.headless }
+    }),
+    DEFAULT_BACKEND_CONFIG
+  );
+}

--- a/src/backends/config.ts
+++ b/src/backends/config.ts
@@ -72,13 +72,35 @@ export function validateBackendConfig(config: BackendConfig): string[] {
   return issues;
 }
 
+function mergeSearchConfig(
+  current: SearchBackendConfig,
+  override: Partial<SearchBackendConfig> | undefined
+): SearchBackendConfig {
+  if (!override) return current;
+  if (override.provider && override.provider !== current.provider) {
+    return { ...override, provider: override.provider };
+  }
+  return { ...current, ...override };
+}
+
+function mergeFetchConfig(
+  current: FetchBackendConfig,
+  override: Partial<FetchBackendConfig> | undefined
+): FetchBackendConfig {
+  if (!override) return current;
+  if (override.provider && override.provider !== current.provider) {
+    return { ...override, provider: override.provider };
+  }
+  return { ...current, ...override };
+}
+
 export function mergeBackendConfigLayers(
   ...layers: Array<BackendConfig | BackendConfigOverride | undefined>
 ): BackendConfig {
   return layers.reduce<BackendConfig>(
     (merged, layer) => ({
-      search: { ...merged.search, ...layer?.search },
-      fetch: { ...merged.fetch, ...layer?.fetch },
+      search: mergeSearchConfig(merged.search, layer?.search),
+      fetch: mergeFetchConfig(merged.fetch, layer?.fetch),
       headless: { ...merged.headless, ...layer?.headless }
     }),
     DEFAULT_BACKEND_CONFIG

--- a/src/backends/config.ts
+++ b/src/backends/config.ts
@@ -58,6 +58,20 @@ export function extractBackendConfigOverride(
   return override;
 }
 
+export function validateBackendConfig(config: BackendConfig): string[] {
+  const issues: string[] = [];
+
+  if (config.search.provider === 'searxng' && !config.search.baseUrl) {
+    issues.push('search provider searxng requires backends.search.baseUrl');
+  }
+
+  if (config.fetch.provider === 'firecrawl' && !config.fetch.baseUrl) {
+    issues.push('fetch provider firecrawl requires backends.fetch.baseUrl');
+  }
+
+  return issues;
+}
+
 export function mergeBackendConfigLayers(
   ...layers: Array<BackendConfig | BackendConfigOverride | undefined>
 ): BackendConfig {

--- a/src/backends/doctor.ts
+++ b/src/backends/doctor.ts
@@ -1,0 +1,77 @@
+import type { BackendConfig } from './config.js';
+
+function withTimeout(timeoutMs: number) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  return { signal: controller.signal, done: () => clearTimeout(timeout) };
+}
+
+function message(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function searxngDoctorUrl(baseUrl: string) {
+  const url = new URL('/search', baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`);
+  url.searchParams.set('q', 'pi-web-agent-doctor');
+  url.searchParams.set('format', 'json');
+  return url.toString();
+}
+
+export async function checkBackendHealth(
+  config: BackendConfig,
+  {
+    fetchImpl = fetch,
+    timeoutMs = 3_000
+  }: {
+    fetchImpl?: typeof fetch;
+    timeoutMs?: number;
+  } = {}
+): Promise<string[]> {
+  const lines: string[] = [];
+
+  if (config.search.provider === 'duckduckgo') {
+    lines.push('search backend: duckduckgo');
+  } else if (!config.search.baseUrl) {
+    lines.push('search backend: searxng warning (missing baseUrl)');
+  } else {
+    const timeout = withTimeout(timeoutMs);
+    try {
+      const response = await fetchImpl(searxngDoctorUrl(config.search.baseUrl), { signal: timeout.signal });
+      const json = (await response.json()) as { results?: unknown };
+      lines.push(response.ok && Array.isArray(json.results)
+        ? 'search backend: searxng ok'
+        : 'search backend: searxng warning (unexpected response)');
+    } catch (error) {
+      lines.push(`search backend: searxng warning (${message(error)})`);
+    } finally {
+      timeout.done();
+    }
+  }
+
+  if (config.fetch.provider === 'http') {
+    lines.push('fetch backend: http');
+  } else if (!config.fetch.baseUrl) {
+    lines.push('fetch backend: firecrawl warning (missing baseUrl)');
+  } else {
+    const timeout = withTimeout(timeoutMs);
+    try {
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      if (config.fetch.apiKey ?? process.env.PI_WEB_AGENT_FIRECRAWL_API_KEY) {
+        headers.Authorization = `Bearer ${config.fetch.apiKey ?? process.env.PI_WEB_AGENT_FIRECRAWL_API_KEY}`;
+      }
+      const response = await fetchImpl(new URL('/v1/scrape', config.fetch.baseUrl).toString(), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ url: 'https://example.com', formats: ['markdown'] }),
+        signal: timeout.signal
+      });
+      lines.push(response.ok ? 'fetch backend: firecrawl ok' : `fetch backend: firecrawl warning (HTTP ${response.status})`);
+    } catch (error) {
+      lines.push(`fetch backend: firecrawl warning (${message(error)})`);
+    } finally {
+      timeout.done();
+    }
+  }
+
+  return lines;
+}

--- a/src/backends/factory.ts
+++ b/src/backends/factory.ts
@@ -1,3 +1,5 @@
+import { createFirecrawlFetcher } from '../fetch/firecrawl-fetch.js';
+import { createSearxngSearchTool } from '../search/searxng.js';
 import { createWebFetchHeadlessTool } from '../tools/web-fetch-headless.js';
 import { createWebFetchTool } from '../tools/web-fetch.js';
 import { createWebSearchTool } from '../tools/web-search.js';
@@ -10,10 +12,23 @@ export type BackendSet = {
   headlessFetch: (input: { url: string }) => Promise<WebFetchHeadlessResponse>;
 };
 
-export function createBackendSet(_config: BackendConfig = DEFAULT_BACKEND_CONFIG): BackendSet {
+export function createBackendSet(config: BackendConfig = DEFAULT_BACKEND_CONFIG): BackendSet {
+  const search = config.search.provider === 'searxng' && config.search.baseUrl
+    ? createSearxngSearchTool({ baseUrl: config.search.baseUrl })
+    : createWebSearchTool();
+
+  const fetchPage = config.fetch.provider === 'firecrawl' && config.fetch.baseUrl
+    ? createWebFetchTool({
+        fetchPage: createFirecrawlFetcher({
+          baseUrl: config.fetch.baseUrl,
+          apiKey: config.fetch.apiKey
+        })
+      })
+    : createWebFetchTool();
+
   return {
-    search: createWebSearchTool(),
-    fetchPage: createWebFetchTool(),
+    search,
+    fetchPage,
     headlessFetch: createWebFetchHeadlessTool()
   };
 }

--- a/src/backends/factory.ts
+++ b/src/backends/factory.ts
@@ -1,5 +1,7 @@
 import { createFirecrawlFetcher } from '../fetch/firecrawl-fetch.js';
 import { createSearxngSearchTool } from '../search/searxng.js';
+import { buildFetchPresentation } from '../presentation/fetch-presentation.js';
+import { buildSearchPresentation } from '../presentation/search-presentation.js';
 import { createWebFetchHeadlessTool } from '../tools/web-fetch-headless.js';
 import { createWebFetchTool } from '../tools/web-fetch.js';
 import { createWebSearchTool } from '../tools/web-search.js';
@@ -12,18 +14,54 @@ export type BackendSet = {
   headlessFetch: (input: { url: string }) => Promise<WebFetchHeadlessResponse>;
 };
 
+function invalidSearxngSearch() {
+  return async function search() {
+    const result: WebSearchResponse = {
+      status: 'error',
+      results: [],
+      metadata: { backend: 'searxng', cacheHit: false },
+      error: {
+        code: 'BACKEND_CONFIG_INVALID',
+        message: 'SearXNG search requires backends.search.baseUrl.'
+      }
+    };
+
+    return { ...result, presentation: buildSearchPresentation(result) };
+  };
+}
+
+function invalidFirecrawlFetch() {
+  return async function fetchPage(url: string): Promise<WebFetchResponse> {
+    const result: WebFetchResponse = {
+      status: 'error',
+      url,
+      metadata: { method: 'firecrawl', cacheHit: false },
+      error: {
+        code: 'BACKEND_CONFIG_INVALID',
+        message: 'Firecrawl fetch requires backends.fetch.baseUrl.'
+      }
+    };
+
+    return { ...result, presentation: buildFetchPresentation(result) };
+  };
+}
+
 export function createBackendSet(config: BackendConfig = DEFAULT_BACKEND_CONFIG): BackendSet {
-  const search = config.search.provider === 'searxng' && config.search.baseUrl
-    ? createSearxngSearchTool({ baseUrl: config.search.baseUrl })
+  const search = config.search.provider === 'searxng'
+    ? config.search.baseUrl
+      ? createSearxngSearchTool({ baseUrl: config.search.baseUrl })
+      : invalidSearxngSearch()
     : createWebSearchTool();
 
-  const fetchPage = config.fetch.provider === 'firecrawl' && config.fetch.baseUrl
-    ? createWebFetchTool({
-        fetchPage: createFirecrawlFetcher({
-          baseUrl: config.fetch.baseUrl,
-          apiKey: config.fetch.apiKey
+  const fetchPage = config.fetch.provider === 'firecrawl'
+    ? config.fetch.baseUrl
+      ? createWebFetchTool({
+          fetchPage: createFirecrawlFetcher({
+            baseUrl: config.fetch.baseUrl,
+            apiKey: config.fetch.apiKey ?? process.env.PI_WEB_AGENT_FIRECRAWL_API_KEY
+          })
         })
-      })
+      : createWebFetchTool({ fetchPage: invalidFirecrawlFetch() })
     : createWebFetchTool();
 
   return {

--- a/src/backends/factory.ts
+++ b/src/backends/factory.ts
@@ -1,0 +1,19 @@
+import { createWebFetchHeadlessTool } from '../tools/web-fetch-headless.js';
+import { createWebFetchTool } from '../tools/web-fetch.js';
+import { createWebSearchTool } from '../tools/web-search.js';
+import type { WebFetchHeadlessResponse, WebFetchResponse, WebSearchResponse } from '../types.js';
+import { DEFAULT_BACKEND_CONFIG, type BackendConfig } from './config.js';
+
+export type BackendSet = {
+  search: (input: { query: string }) => Promise<WebSearchResponse>;
+  fetchPage: (input: { url: string }) => Promise<WebFetchResponse>;
+  headlessFetch: (input: { url: string }) => Promise<WebFetchHeadlessResponse>;
+};
+
+export function createBackendSet(_config: BackendConfig = DEFAULT_BACKEND_CONFIG): BackendSet {
+  return {
+    search: createWebSearchTool(),
+    fetchPage: createWebFetchTool(),
+    headlessFetch: createWebFetchHeadlessTool()
+  };
+}

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BACKEND_CONFIG, type BackendConfig } from '../backends/config.js';
 import {
   DynamicBorder,
   getSettingsListTheme,
@@ -65,6 +66,14 @@ async function defaultCheckTypebox(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function formatBackendSummary(config: BackendConfig = DEFAULT_BACKEND_CONFIG) {
+  return [
+    `search: ${config.search.provider}`,
+    `fetch: ${config.fetch.provider}`,
+    `headless: ${config.headless.provider}`
+  ].join('\n');
 }
 
 function formatConfigSummary(config: PresentationConfig) {
@@ -387,11 +396,12 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
       }
 
       if (action === 'doctor') {
-        const [typeboxOk, browser] = await Promise.all([checkTypebox(), resolveBrowser()]);
+        const [typeboxOk, browser, loaded] = await Promise.all([checkTypebox(), resolveBrowser(), load()]);
         const lines = [
           'pi-web-agent: loaded',
           `runtime: node ${runtime.nodeVersion} ${runtime.platform} ${runtime.arch}`,
-          `typebox: ${typeboxOk ? 'ok' : 'missing'}`
+          `typebox: ${typeboxOk ? 'ok' : 'missing'}`,
+          formatBackendSummary(loaded.effectiveBackends ?? DEFAULT_BACKEND_CONFIG)
         ];
 
         if (browser.ok) {
@@ -411,6 +421,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
         ctx.ui.notify(
           [
             formatConfigSummary(loaded.effectiveConfig),
+            formatBackendSummary(loaded.effectiveBackends ?? DEFAULT_BACKEND_CONFIG),
             `global: ${loaded.global.path}${loaded.global.exists ? '' : ' (missing)'}`,
             `project: ${loaded.project.path}${loaded.project.exists ? '' : ' (missing)'}`
           ].join('\n'),

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_BACKEND_CONFIG, type BackendConfig } from '../backends/config.js';
+import { DEFAULT_BACKEND_CONFIG, validateBackendConfig, type BackendConfig } from '../backends/config.js';
+import { checkBackendHealth } from '../backends/doctor.js';
 import {
   DynamicBorder,
   getSettingsListTheme,
@@ -31,6 +32,7 @@ type CommandDeps = {
   resolveBrowser?: () => Promise<BrowserResolutionResult>;
   runtime?: { nodeVersion: string; platform: string; arch: string };
   checkTypebox?: () => Promise<boolean>;
+  checkBackends?: (config: BackendConfig) => Promise<string[]>;
 };
 
 type SettingsUiResult =
@@ -381,6 +383,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
     arch: process.arch
   };
   const checkTypebox = deps.checkTypebox ?? defaultCheckTypebox;
+  const checkBackends = deps.checkBackends ?? ((config: BackendConfig) => checkBackendHealth(config));
 
   pi.registerCommand('web-agent', {
     description: 'Open settings or manage pi-web-agent presentation config',
@@ -404,11 +407,16 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
 
       if (action === 'doctor') {
         const [typeboxOk, browser, loaded] = await Promise.all([checkTypebox(), resolveBrowser(), load()]);
+        const backendConfig = loaded.effectiveBackends ?? DEFAULT_BACKEND_CONFIG;
+        const backendIssues = validateBackendConfig(backendConfig);
+        const backendHealth = await checkBackends(backendConfig);
         const lines = [
           'pi-web-agent: loaded',
           `runtime: node ${runtime.nodeVersion} ${runtime.platform} ${runtime.arch}`,
           `typebox: ${typeboxOk ? 'ok' : 'missing'}`,
-          formatBackendSummary(loaded.effectiveBackends ?? DEFAULT_BACKEND_CONFIG)
+          formatBackendSummary(backendConfig),
+          backendIssues.length > 0 ? `backend config: warning\n${backendIssues.join('\n')}` : 'backend config: ok',
+          ...backendHealth
         ];
 
         if (browser.ok) {

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -69,9 +69,16 @@ async function defaultCheckTypebox(): Promise<boolean> {
 }
 
 function formatBackendSummary(config: BackendConfig = DEFAULT_BACKEND_CONFIG) {
+  const search = config.search.baseUrl
+    ? `search: ${config.search.provider} (${config.search.baseUrl})`
+    : `search: ${config.search.provider}`;
+  const fetch = config.fetch.baseUrl
+    ? `fetch: ${config.fetch.provider} (${config.fetch.baseUrl})`
+    : `fetch: ${config.fetch.provider}`;
+
   return [
-    `search: ${config.search.provider}`,
-    `fetch: ${config.fetch.provider}`,
+    search,
+    fetch,
     `headless: ${config.headless.provider}`
   ].join('\n');
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,23 @@ export default function extension(pi: ExtensionAPI) {
   registerWebAgentConfigCommands(pi);
 
   const injectedWebExplore = (pi as ExtensionAPI & { __webExploreTool?: ReturnType<typeof createWebExploreTool> }).__webExploreTool;
+  let cachedBackendKey: string | undefined;
+  let cachedWebExplore: ReturnType<typeof createWebExploreTool> | undefined;
+
+  async function getConfiguredWebExplore() {
+    if (injectedWebExplore) return injectedWebExplore;
+
+    const backendConfig = await getEffectiveBackendConfig(pi);
+    const backendKey = JSON.stringify(backendConfig);
+    if (!cachedWebExplore || cachedBackendKey !== backendKey) {
+      cachedBackendKey = backendKey;
+      cachedWebExplore = createWebExploreTool({
+        explore: createResearchWorkflow({ backendConfig })
+      });
+    }
+
+    return cachedWebExplore;
+  }
 
   pi.on('before_agent_start', async (event) => ({
     systemPrompt:
@@ -80,9 +97,7 @@ export default function extension(pi: ExtensionAPI) {
       query: Type.String({ description: 'Web research question to explore.' })
     }),
     async execute(_toolCallId, params) {
-      const webExplore = injectedWebExplore ?? createWebExploreTool({
-        explore: createResearchWorkflow({ backendConfig: await getEffectiveBackendConfig(pi) })
-      });
+      const webExplore = await getConfiguredWebExplore();
       const result: WebExploreResponse = await webExplore({ query: params.query });
       return {
         content: [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,9 @@
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { DEFAULT_BACKEND_CONFIG, type BackendConfig } from './backends/config.js';
 import { Type } from 'typebox';
 import { registerWebAgentConfigCommands } from './commands/web-agent-config.js';
 import { DEFAULT_PRESENTATION_CONFIG, resolvePresentationMode } from './presentation/config.js';
+import { createResearchWorkflow } from './orchestration/index.js';
 import { loadPresentationConfigLayers } from './presentation/config-store.js';
 import { selectPresentationView } from './presentation/select-view.js';
 import type {
@@ -16,7 +18,7 @@ type ToolResultWithPresentation = {
   presentation?: PresentationEnvelope;
 };
 
-async function getEffectivePresentationConfig(pi: ExtensionAPI): Promise<PresentationConfig> {
+async function loadWebAgentConfig(pi: ExtensionAPI) {
   const store = (
     pi as ExtensionAPI & {
       __presentationConfigStore?: {
@@ -25,11 +27,24 @@ async function getEffectivePresentationConfig(pi: ExtensionAPI): Promise<Present
     }
   ).__presentationConfigStore;
 
+  return store?.load?.() ?? loadPresentationConfigLayers();
+}
+
+async function getEffectivePresentationConfig(pi: ExtensionAPI): Promise<PresentationConfig> {
   try {
-    const loaded = await (store?.load?.() ?? loadPresentationConfigLayers());
+    const loaded = await loadWebAgentConfig(pi);
     return loaded.effectiveConfig;
   } catch {
     return DEFAULT_PRESENTATION_CONFIG;
+  }
+}
+
+async function getEffectiveBackendConfig(pi: ExtensionAPI): Promise<BackendConfig> {
+  try {
+    const loaded = await loadWebAgentConfig(pi);
+    return loaded.effectiveBackends ?? DEFAULT_BACKEND_CONFIG;
+  } catch {
+    return DEFAULT_BACKEND_CONFIG;
   }
 }
 
@@ -46,9 +61,7 @@ async function renderToolText(
 export default function extension(pi: ExtensionAPI) {
   registerWebAgentConfigCommands(pi);
 
-  const webExplore =
-    (pi as ExtensionAPI & { __webExploreTool?: ReturnType<typeof createWebExploreTool> }).__webExploreTool ??
-    createWebExploreTool();
+  const injectedWebExplore = (pi as ExtensionAPI & { __webExploreTool?: ReturnType<typeof createWebExploreTool> }).__webExploreTool;
 
   pi.on('before_agent_start', async (event) => ({
     systemPrompt:
@@ -67,6 +80,9 @@ export default function extension(pi: ExtensionAPI) {
       query: Type.String({ description: 'Web research question to explore.' })
     }),
     async execute(_toolCallId, params) {
+      const webExplore = injectedWebExplore ?? createWebExploreTool({
+        explore: createResearchWorkflow({ backendConfig: await getEffectiveBackendConfig(pi) })
+      });
       const result: WebExploreResponse = await webExplore({ query: params.query });
       return {
         content: [

--- a/src/fetch/firecrawl-fetch.ts
+++ b/src/fetch/firecrawl-fetch.ts
@@ -1,0 +1,91 @@
+import type { WebFetchResponse } from '../types.js';
+
+type FirecrawlResponse = {
+  success?: boolean;
+  data?: {
+    markdown?: unknown;
+    html?: unknown;
+    metadata?: {
+      title?: unknown;
+      sourceURL?: unknown;
+    };
+  };
+  error?: unknown;
+};
+
+function buildScrapeUrl(baseUrl: string) {
+  return new URL('/v1/scrape', baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`).toString();
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createFirecrawlFetcher({
+  baseUrl,
+  apiKey,
+  fetchImpl = fetch
+}: {
+  baseUrl: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}) {
+  return async function firecrawlFetch(url: string): Promise<WebFetchResponse> {
+    try {
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      if (apiKey) {
+        headers.Authorization = `Bearer ${apiKey}`;
+      }
+
+      const response = await fetchImpl(buildScrapeUrl(baseUrl), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ url, formats: ['markdown'] })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const parsed = (await response.json()) as FirecrawlResponse;
+      if (parsed.success === false) {
+        throw new Error(typeof parsed.error === 'string' ? parsed.error : 'Firecrawl scrape failed.');
+      }
+
+      const text = typeof parsed.data?.markdown === 'string'
+        ? parsed.data.markdown
+        : typeof parsed.data?.html === 'string'
+          ? parsed.data.html
+          : '';
+      const resolvedUrl = typeof parsed.data?.metadata?.sourceURL === 'string'
+        ? parsed.data.metadata.sourceURL
+        : url;
+      const title = typeof parsed.data?.metadata?.title === 'string'
+        ? parsed.data.metadata.title
+        : undefined;
+
+      if (!text.trim()) {
+        return {
+          status: 'needs_headless',
+          url: resolvedUrl,
+          metadata: { method: 'firecrawl', cacheHit: false },
+          error: { code: 'WEAK_EXTRACTION', message: 'Firecrawl did not return useful page text.' }
+        };
+      }
+
+      return {
+        status: 'ok',
+        url: resolvedUrl,
+        content: { title, text },
+        metadata: { method: 'firecrawl', cacheHit: false, truncated: text.length >= 4000 }
+      };
+    } catch (error) {
+      return {
+        status: 'error',
+        url,
+        metadata: { method: 'firecrawl', cacheHit: false },
+        error: { code: 'FETCH_FAILED', message: `Firecrawl scrape failed: ${errorMessage(error)}` }
+      };
+    }
+  };
+}

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -1,19 +1,24 @@
+import { createBackendSet } from '../backends/factory.js';
+import type { BackendConfig } from '../backends/config.js';
 import type { WebFetchHeadlessResponse, WebFetchResponse, WebSearchResponse } from '../types.js';
-import { createWebFetchHeadlessTool } from '../tools/web-fetch-headless.js';
-import { createWebFetchTool } from '../tools/web-fetch.js';
-import { createWebSearchTool } from '../tools/web-search.js';
 import { createResearchOrchestrator } from './research-orchestrator.js';
 import { createResearchWorker } from './research-worker.js';
 
 export function createResearchWorkflow({
-  search = createWebSearchTool(),
-  fetchPage = createWebFetchTool(),
-  headlessFetch = createWebFetchHeadlessTool()
+  backendConfig,
+  search,
+  fetchPage,
+  headlessFetch
 }: {
+  backendConfig?: BackendConfig;
   search?: (input: { query: string }) => Promise<WebSearchResponse>;
   fetchPage?: (input: { url: string }) => Promise<WebFetchResponse>;
   headlessFetch?: (input: { url: string }) => Promise<WebFetchHeadlessResponse>;
 } = {}) {
-  const worker = createResearchWorker({ search, fetchPage });
-  return createResearchOrchestrator({ worker, headlessFetch });
+  const backends = createBackendSet(backendConfig);
+  const resolvedSearch = search ?? backends.search;
+  const resolvedFetchPage = fetchPage ?? backends.fetchPage;
+  const resolvedHeadlessFetch = headlessFetch ?? backends.headlessFetch;
+  const worker = createResearchWorker({ search: resolvedSearch, fetchPage: resolvedFetchPage });
+  return createResearchOrchestrator({ worker, headlessFetch: resolvedHeadlessFetch });
 }

--- a/src/orchestration/research-types.ts
+++ b/src/orchestration/research-types.ts
@@ -7,7 +7,7 @@ export type ResearchSourceKind =
   | 'package-page'
   | 'other';
 
-export type ResearchMethod = 'search' | 'http' | 'headless';
+export type ResearchMethod = 'search' | 'http' | 'headless' | 'firecrawl';
 
 export type ResearchEvidence = {
   title: string;

--- a/src/presentation/config-store.ts
+++ b/src/presentation/config-store.ts
@@ -1,6 +1,14 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
+  DEFAULT_BACKEND_CONFIG,
+  extractBackendConfigOverride,
+  mergeBackendConfigLayers,
+  type BackendConfig,
+  type BackendConfigFile,
+  type BackendConfigOverride
+} from '../backends/config.js';
+import {
   DEFAULT_PRESENTATION_CONFIG,
   extractPresentationConfigOverride,
   mergePresentationConfigLayers
@@ -21,6 +29,7 @@ export type PresentationConfigLayer = {
   path: string;
   exists: boolean;
   rawConfig?: PresentationConfigOverride;
+  rawBackends?: BackendConfigOverride;
   error?: string;
 };
 
@@ -28,6 +37,7 @@ export type LoadedPresentationConfig = {
   global: PresentationConfigLayer;
   project: PresentationConfigLayer;
   effectiveConfig: PresentationConfig;
+  effectiveBackends: BackendConfig;
 };
 
 export function getPresentationConfigPaths(options: PresentationConfigStoreOptions = {}) {
@@ -40,15 +50,27 @@ export function getPresentationConfigPaths(options: PresentationConfigStoreOptio
   };
 }
 
+type AgentConfigFile = PresentationConfigFile & BackendConfigFile;
+
+type LegacyPresentationConfigFile = NonNullable<PresentationConfigFile['presentation']>;
+
+function hasPresentationRoot(parsed: AgentConfigFile) {
+  return parsed.presentation !== undefined;
+}
+
 async function readPresentationConfigFile(filePath: string): Promise<PresentationConfigLayer> {
   try {
     const rawText = await readFile(filePath, 'utf8');
-    const parsed = JSON.parse(rawText) as PresentationConfigFile;
+    const parsed = JSON.parse(rawText) as AgentConfigFile;
+    const presentationFile: PresentationConfigFile = hasPresentationRoot(parsed)
+      ? parsed
+      : { presentation: parsed as LegacyPresentationConfigFile };
 
     return {
       path: filePath,
       exists: true,
-      rawConfig: extractPresentationConfigOverride(parsed)
+      rawConfig: extractPresentationConfigOverride(presentationFile),
+      rawBackends: extractBackendConfigOverride(parsed)
     };
   } catch (error) {
     if ((error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT') {
@@ -92,6 +114,11 @@ export async function loadPresentationConfigLayers(
       DEFAULT_PRESENTATION_CONFIG,
       global.rawConfig,
       project.rawConfig
+    ),
+    effectiveBackends: mergeBackendConfigLayers(
+      DEFAULT_BACKEND_CONFIG,
+      global.rawBackends,
+      project.rawBackends
     )
   };
 }

--- a/src/presentation/explore-presentation.ts
+++ b/src/presentation/explore-presentation.ts
@@ -1,8 +1,9 @@
 import type { WebExploreResponse } from '../types.js';
 import type { PresentationEnvelope } from './types.js';
 
-function internalReaderLabel(method?: 'http' | 'headless') {
+function internalReaderLabel(method?: 'http' | 'headless' | 'firecrawl') {
   if (method === 'headless') return 'web_fetch_headless';
+  if (method === 'firecrawl') return 'firecrawl';
   if (method === 'http') return 'web_fetch';
   return 'web_explore';
 }

--- a/src/search/searxng.ts
+++ b/src/search/searxng.ts
@@ -1,0 +1,90 @@
+import { buildSearchPresentation } from '../presentation/search-presentation.js';
+import type { SearchResult, WebSearchResponse } from '../types.js';
+
+type SearxngResult = {
+  title?: unknown;
+  url?: unknown;
+  content?: unknown;
+};
+
+type SearxngResponse = {
+  results?: SearxngResult[];
+};
+
+function buildSearchUrl(baseUrl: string, query: string) {
+  const url = new URL('/search', baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`);
+  url.searchParams.set('q', query);
+  url.searchParams.set('format', 'json');
+  return url.toString();
+}
+
+function normalizeResults(response: SearxngResponse): SearchResult[] {
+  return (response.results ?? []).flatMap((result) => {
+    if (typeof result.title !== 'string' || typeof result.url !== 'string') {
+      return [];
+    }
+
+    return [
+      {
+        title: result.title,
+        url: result.url,
+        snippet: typeof result.content === 'string' ? result.content : ''
+      }
+    ];
+  });
+}
+
+export function createSearxngSearchTool({
+  baseUrl,
+  fetchImpl = fetch
+}: {
+  baseUrl: string;
+  fetchImpl?: typeof fetch;
+}) {
+  return async function searxngSearch({ query }: { query: string }): Promise<WebSearchResponse> {
+    const normalizedQuery = query.trim();
+
+    if (!normalizedQuery) {
+      const result: WebSearchResponse = {
+        status: 'error',
+        results: [],
+        metadata: { backend: 'searxng', cacheHit: false },
+        error: { code: 'INVALID_QUERY', message: 'Query must not be empty.' }
+      };
+      return { ...result, presentation: buildSearchPresentation(result) };
+    }
+
+    try {
+      const response = await fetchImpl(buildSearchUrl(baseUrl, normalizedQuery));
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const parsed = (await response.json()) as SearxngResponse;
+      const results = normalizeResults(parsed);
+      const result: WebSearchResponse = results.length > 0
+        ? {
+            status: 'ok',
+            results,
+            metadata: { backend: 'searxng', cacheHit: false }
+          }
+        : {
+            status: 'error',
+            results: [],
+            metadata: { backend: 'searxng', cacheHit: false },
+            error: { code: 'NO_RESULTS', message: 'SearXNG returned no usable results for this query.' }
+          };
+
+      return { ...result, presentation: buildSearchPresentation(result) };
+    } catch (error) {
+      const rawMessage = error instanceof Error ? error.message : String(error);
+      const result: WebSearchResponse = {
+        status: 'error',
+        results: [],
+        metadata: { backend: 'searxng', cacheHit: false },
+        error: { code: 'FETCH_FAILED', message: `SearXNG search request failed: ${rawMessage}` }
+      };
+      return { ...result, presentation: buildSearchPresentation(result) };
+    }
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,12 +22,12 @@ export type ToolError = {
 };
 
 export type SearchMetadata = {
-  backend: 'duckduckgo';
+  backend: 'duckduckgo' | 'searxng';
   cacheHit: boolean;
 };
 
 export type FetchMetadata = {
-  method: 'http' | 'headless';
+  method: 'http' | 'headless' | 'firecrawl';
   cacheHit: boolean;
   contentType?: string;
   truncated?: boolean;
@@ -70,7 +70,7 @@ export type WebFetchHeadlessResponse = {
 export type WebExploreResponse = {
   status: 'ok' | 'error';
   findings: string[];
-  sources: Array<{ title: string; url: string; method?: 'http' | 'headless' }>;
+  sources: Array<{ title: string; url: string; method?: 'http' | 'headless' | 'firecrawl' }>;
   caveat?: string;
   metadata?: {
     searchPasses: number;

--- a/tests/backends/config.test.ts
+++ b/tests/backends/config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_BACKEND_CONFIG, mergeBackendConfigLayers } from '../../src/backends/config.js';
+
+describe('backend config', () => {
+  it('defaults to existing providers', () => {
+    expect(DEFAULT_BACKEND_CONFIG).toEqual({
+      search: { provider: 'duckduckgo' },
+      fetch: { provider: 'http' },
+      headless: { provider: 'local-browser' }
+    });
+  });
+
+  it('merges project overrides over global overrides', () => {
+    expect(
+      mergeBackendConfigLayers(
+        DEFAULT_BACKEND_CONFIG,
+        { search: { provider: 'duckduckgo' }, fetch: { provider: 'http' } },
+        { headless: { provider: 'local-browser' } }
+      )
+    ).toEqual(DEFAULT_BACKEND_CONFIG);
+  });
+});

--- a/tests/backends/config.test.ts
+++ b/tests/backends/config.test.ts
@@ -18,8 +18,28 @@ describe('backend config', () => {
         { search: { provider: 'duckduckgo' }, fetch: { provider: 'firecrawl', baseUrl: 'http://firecrawl' } }
       )
     ).toEqual({
-      search: { provider: 'duckduckgo', baseUrl: 'http://global-searxng' },
+      search: { provider: 'duckduckgo' },
       fetch: { provider: 'firecrawl', baseUrl: 'http://firecrawl' },
+      headless: { provider: 'local-browser' }
+    });
+  });
+
+  it('drops provider-specific fields when a higher-precedence layer changes provider', () => {
+    expect(
+      mergeBackendConfigLayers(
+        DEFAULT_BACKEND_CONFIG,
+        {
+          search: { provider: 'searxng', baseUrl: 'http://global-searxng' },
+          fetch: { provider: 'firecrawl', baseUrl: 'http://global-firecrawl', apiKey: 'global-key' }
+        },
+        {
+          search: { provider: 'duckduckgo' },
+          fetch: { provider: 'http' }
+        }
+      )
+    ).toEqual({
+      search: { provider: 'duckduckgo' },
+      fetch: { provider: 'http' },
       headless: { provider: 'local-browser' }
     });
   });

--- a/tests/backends/config.test.ts
+++ b/tests/backends/config.test.ts
@@ -14,9 +14,26 @@ describe('backend config', () => {
     expect(
       mergeBackendConfigLayers(
         DEFAULT_BACKEND_CONFIG,
-        { search: { provider: 'duckduckgo' }, fetch: { provider: 'http' } },
-        { headless: { provider: 'local-browser' } }
+        { search: { provider: 'searxng', baseUrl: 'http://global-searxng' }, fetch: { provider: 'http' } },
+        { search: { provider: 'duckduckgo' }, fetch: { provider: 'firecrawl', baseUrl: 'http://firecrawl' } }
       )
-    ).toEqual(DEFAULT_BACKEND_CONFIG);
+    ).toEqual({
+      search: { provider: 'duckduckgo', baseUrl: 'http://global-searxng' },
+      fetch: { provider: 'firecrawl', baseUrl: 'http://firecrawl' },
+      headless: { provider: 'local-browser' }
+    });
+  });
+
+  it('extracts self-hosted backend config', () => {
+    expect(
+      mergeBackendConfigLayers(DEFAULT_BACKEND_CONFIG, {
+        search: { provider: 'searxng', baseUrl: 'http://localhost:8080' },
+        fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', apiKey: 'test-key' }
+      })
+    ).toEqual({
+      search: { provider: 'searxng', baseUrl: 'http://localhost:8080' },
+      fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', apiKey: 'test-key' },
+      headless: { provider: 'local-browser' }
+    });
   });
 });

--- a/tests/backends/doctor.test.ts
+++ b/tests/backends/doctor.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { checkBackendHealth } from '../../src/backends/doctor.js';
+
+describe('backend doctor checks', () => {
+  it('does not network-check default local backends', async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(
+      checkBackendHealth({
+        search: { provider: 'duckduckgo' },
+        fetch: { provider: 'http' },
+        headless: { provider: 'local-browser' }
+      }, { fetchImpl })
+    ).resolves.toEqual(['search backend: duckduckgo', 'fetch backend: http']);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('checks configured SearXNG JSON search endpoint', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] })
+    } as Response);
+
+    await expect(
+      checkBackendHealth({
+        search: { provider: 'searxng', baseUrl: 'http://localhost:8080' },
+        fetch: { provider: 'http' },
+        headless: { provider: 'local-browser' }
+      }, { fetchImpl })
+    ).resolves.toContain('search backend: searxng ok');
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:8080/search?q=pi-web-agent-doctor&format=json',
+      expect.any(Object)
+    );
+  });
+
+  it('reports Firecrawl health check failures as warnings', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    await expect(
+      checkBackendHealth({
+        search: { provider: 'duckduckgo' },
+        fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002' },
+        headless: { provider: 'local-browser' }
+      }, { fetchImpl })
+    ).resolves.toContain('fetch backend: firecrawl warning (connect ECONNREFUSED)');
+  });
+});

--- a/tests/backends/factory.test.ts
+++ b/tests/backends/factory.test.ts
@@ -20,4 +20,24 @@ describe('backend factory', () => {
     expect(backends.search).toEqual(expect.any(Function));
     expect(backends.fetchPage).toEqual(expect.any(Function));
   });
+
+  it('returns clear backend config errors instead of silently falling back', async () => {
+    const backends = createBackendSet({
+      search: { provider: 'searxng' },
+      fetch: { provider: 'firecrawl' },
+      headless: { provider: 'local-browser' }
+    });
+
+    await expect(backends.search({ query: 'docs' })).resolves.toMatchObject({
+      status: 'error',
+      metadata: { backend: 'searxng', cacheHit: false },
+      error: { code: 'BACKEND_CONFIG_INVALID' }
+    });
+
+    await expect(backends.fetchPage({ url: 'https://example.com' })).resolves.toMatchObject({
+      status: 'error',
+      metadata: { method: 'firecrawl', cacheHit: false },
+      error: { code: 'BACKEND_CONFIG_INVALID' }
+    });
+  });
 });

--- a/tests/backends/factory.test.ts
+++ b/tests/backends/factory.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { createBackendSet } from '../../src/backends/factory.js';
+
+describe('backend factory', () => {
+  it('creates the existing search/fetch/headless tools by default', () => {
+    const backends = createBackendSet();
+
+    expect(backends.search).toEqual(expect.any(Function));
+    expect(backends.fetchPage).toEqual(expect.any(Function));
+    expect(backends.headlessFetch).toEqual(expect.any(Function));
+  });
+});

--- a/tests/backends/factory.test.ts
+++ b/tests/backends/factory.test.ts
@@ -9,4 +9,15 @@ describe('backend factory', () => {
     expect(backends.fetchPage).toEqual(expect.any(Function));
     expect(backends.headlessFetch).toEqual(expect.any(Function));
   });
+
+  it('creates self-hosted search and fetch backends', () => {
+    const backends = createBackendSet({
+      search: { provider: 'searxng', baseUrl: 'http://localhost:8080' },
+      fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002' },
+      headless: { provider: 'local-browser' }
+    });
+
+    expect(backends.search).toEqual(expect.any(Function));
+    expect(backends.fetchPage).toEqual(expect.any(Function));
+  });
 });

--- a/tests/backends/validation.test.ts
+++ b/tests/backends/validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { validateBackendConfig } from '../../src/backends/config.js';
+
+describe('backend config validation', () => {
+  it('accepts default backend config', () => {
+    expect(
+      validateBackendConfig({
+        search: { provider: 'duckduckgo' },
+        fetch: { provider: 'http' },
+        headless: { provider: 'local-browser' }
+      })
+    ).toEqual([]);
+  });
+
+  it('requires baseUrl for self-hosted providers', () => {
+    expect(
+      validateBackendConfig({
+        search: { provider: 'searxng' },
+        fetch: { provider: 'firecrawl' },
+        headless: { provider: 'local-browser' }
+      })
+    ).toEqual([
+      'search provider searxng requires backends.search.baseUrl',
+      'fetch provider firecrawl requires backends.fetch.baseUrl'
+    ]);
+  });
+});

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -36,7 +36,12 @@ describe('web-agent config draft helpers', () => {
         {
           tools: { web_explore: { mode: 'compact' } }
         }
-      )
+      ),
+      effectiveBackends: {
+        search: { provider: 'duckduckgo' as const },
+        fetch: { provider: 'http' as const },
+        headless: { provider: 'local-browser' as const }
+      }
     };
 
     const initialState = createSettingsDraftState(loaded, 'project');
@@ -118,6 +123,9 @@ describe('web-agent config commands', () => {
     expect(notify.mock.calls[0][0]).toContain('runtime: node v24.0.0 linux x64');
     expect(notify.mock.calls[0][0]).toContain('typebox: ok');
     expect(notify.mock.calls[0][0]).toContain('browser: chromium /usr/bin/chromium');
+    expect(notify.mock.calls[0][0]).toContain('search: duckduckgo');
+    expect(notify.mock.calls[0][0]).toContain('fetch: http');
+    expect(notify.mock.calls[0][0]).toContain('headless: local-browser');
   });
 
   it('renders doctor browser failures without throwing', async () => {
@@ -170,6 +178,11 @@ describe('web-agent config commands', () => {
         effectiveConfig: {
           defaultMode: 'preview',
           tools: { web_explore: { mode: 'verbose' } }
+        },
+        effectiveBackends: {
+          search: { provider: 'duckduckgo' },
+          fetch: { provider: 'http' },
+          headless: { provider: 'local-browser' }
         }
       }),
       reset: vi.fn()
@@ -180,6 +193,9 @@ describe('web-agent config commands', () => {
 
     expect(notify).toHaveBeenCalledWith(expect.stringContaining('defaultMode: preview'), 'info');
     expect(notify).toHaveBeenCalledWith(expect.stringContaining('web_explore: verbose'), 'info');
+    expect(notify.mock.calls[0][0]).toContain('search: duckduckgo');
+    expect(notify.mock.calls[0][0]).toContain('fetch: http');
+    expect(notify.mock.calls[0][0]).toContain('headless: local-browser');
     expect(notify.mock.calls[0][0]).not.toContain('web_search:');
     expect(notify.mock.calls[0][0]).not.toContain('web_fetch:');
   });

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -113,7 +113,8 @@ describe('web-agent config commands', () => {
     registerWebAgentConfigCommands(pi as never, {
       resolveBrowser: vi.fn().mockResolvedValue(browser),
       runtime: { nodeVersion: 'v24.0.0', platform: 'linux', arch: 'x64' },
-      checkTypebox: vi.fn().mockResolvedValue(true)
+      checkTypebox: vi.fn().mockResolvedValue(true),
+      checkBackends: vi.fn().mockResolvedValue(['search backend: duckduckgo', 'fetch backend: http'])
     });
 
     const notify = vi.fn();
@@ -126,6 +127,40 @@ describe('web-agent config commands', () => {
     expect(notify.mock.calls[0][0]).toContain('search: duckduckgo');
     expect(notify.mock.calls[0][0]).toContain('fetch: http');
     expect(notify.mock.calls[0][0]).toContain('headless: local-browser');
+    expect(notify.mock.calls[0][0]).toContain('search backend: duckduckgo');
+    expect(notify.mock.calls[0][0]).toContain('fetch backend: http');
+  });
+
+  it('renders backend validation warnings in doctor output', async () => {
+    let handler: any;
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: { path: '/project/config.json', exists: true },
+        effectiveConfig: { defaultMode: 'compact', tools: {} },
+        effectiveBackends: {
+          search: { provider: 'searxng' },
+          fetch: { provider: 'firecrawl' },
+          headless: { provider: 'local-browser' }
+        }
+      }),
+      resolveBrowser: vi.fn().mockResolvedValue({ ok: true, executablePath: '/usr/bin/chromium', browser: 'chromium' }),
+      runtime: { nodeVersion: 'v24.0.0', platform: 'linux', arch: 'x64' },
+      checkTypebox: vi.fn().mockResolvedValue(true)
+    });
+
+    const notify = vi.fn();
+    await handler('doctor', { ui: { notify } });
+
+    expect(notify.mock.calls[0][0]).toContain('backend config: warning');
+    expect(notify.mock.calls[0][0]).toContain('search provider searxng requires backends.search.baseUrl');
+    expect(notify.mock.calls[0][0]).toContain('fetch provider firecrawl requires backends.fetch.baseUrl');
   });
 
   it('renders doctor browser failures without throwing', async () => {

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -2,6 +2,48 @@ import { describe, expect, it, vi } from 'vitest';
 import extension from '../src/extension.js';
 
 describe('Pi extension entrypoint', () => {
+  it('passes configured backends into the default web_explore workflow', async () => {
+    vi.resetModules();
+    const createResearchWorkflow = vi.fn().mockReturnValue({
+      run: vi.fn().mockResolvedValue({
+        decision: { action: 'answer' },
+        evidence: [],
+        workerPass: {},
+        metadata: { searchPasses: 0, fetchedPages: 0, headlessAttempts: 0, exhaustedBudget: false }
+      })
+    });
+    vi.doMock('../src/orchestration/index.js', () => ({ createResearchWorkflow }));
+
+    const { default: dynamicExtension } = await import('../src/extension.js');
+    const tools: any[] = [];
+    const pi = {
+      registerTool: (tool: any) => tools.push(tool),
+      registerCommand: vi.fn(),
+      on: vi.fn(),
+      __presentationConfigStore: {
+        load: vi.fn().mockResolvedValue({
+          effectiveConfig: { defaultMode: 'compact', tools: {} },
+          effectiveBackends: {
+            search: { provider: 'searxng', baseUrl: 'http://localhost:8080' },
+            fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002' },
+            headless: { provider: 'local-browser' }
+          }
+        })
+      }
+    };
+
+    dynamicExtension(pi as never);
+    await tools.find((tool) => tool.name === 'web_explore').execute('tool-call-1', { query: 'example' });
+
+    expect(createResearchWorkflow).toHaveBeenCalledWith({
+      backendConfig: {
+        search: { provider: 'searxng', baseUrl: 'http://localhost:8080' },
+        fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002' },
+        headless: { provider: 'local-browser' }
+      }
+    });
+  });
+
   it('registers the web-agent config commands', () => {
     const pi = {
       registerTool: vi.fn(),

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -2,6 +2,44 @@ import { describe, expect, it, vi } from 'vitest';
 import extension from '../src/extension.js';
 
 describe('Pi extension entrypoint', () => {
+  it('reuses the configured web_explore workflow while backend config is unchanged', async () => {
+    vi.resetModules();
+    const createResearchWorkflow = vi.fn().mockReturnValue({
+      run: vi.fn().mockResolvedValue({
+        decision: { action: 'answer' },
+        evidence: [],
+        workerPass: {},
+        metadata: { searchPasses: 0, fetchedPages: 0, headlessAttempts: 0, exhaustedBudget: false }
+      })
+    });
+    vi.doMock('../src/orchestration/index.js', () => ({ createResearchWorkflow }));
+
+    const { default: dynamicExtension } = await import('../src/extension.js');
+    const tools: any[] = [];
+    const pi = {
+      registerTool: (tool: any) => tools.push(tool),
+      registerCommand: vi.fn(),
+      on: vi.fn(),
+      __presentationConfigStore: {
+        load: vi.fn().mockResolvedValue({
+          effectiveConfig: { defaultMode: 'compact', tools: {} },
+          effectiveBackends: {
+            search: { provider: 'duckduckgo' },
+            fetch: { provider: 'http' },
+            headless: { provider: 'local-browser' }
+          }
+        })
+      }
+    };
+
+    dynamicExtension(pi as never);
+    const webExplore = tools.find((tool) => tool.name === 'web_explore');
+    await webExplore.execute('tool-call-1', { query: 'example' });
+    await webExplore.execute('tool-call-2', { query: 'example again' });
+
+    expect(createResearchWorkflow).toHaveBeenCalledTimes(1);
+  });
+
   it('passes configured backends into the default web_explore workflow', async () => {
     vi.resetModules();
     const createResearchWorkflow = vi.fn().mockReturnValue({

--- a/tests/fetch/firecrawl-fetch.test.ts
+++ b/tests/fetch/firecrawl-fetch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createFirecrawlFetcher } from '../../src/fetch/firecrawl-fetch.js';
+
+describe('firecrawl fetch backend', () => {
+  it('scrapes a URL through Firecrawl and returns extracted markdown', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          markdown: '# Example Docs\n\nUseful Firecrawl extracted content.',
+          metadata: {
+            title: 'Example Docs',
+            sourceURL: 'https://example.com/docs'
+          }
+        }
+      })
+    } as Response);
+
+    const fetcher = createFirecrawlFetcher({ baseUrl: 'http://localhost:3002', apiKey: 'dev-key', fetchImpl });
+    const result = await fetcher('https://example.com/docs');
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:3002/v1/scrape',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer dev-key' }),
+        body: JSON.stringify({ url: 'https://example.com/docs', formats: ['markdown'] })
+      })
+    );
+    expect(result).toMatchObject({
+      status: 'ok',
+      url: 'https://example.com/docs',
+      content: { title: 'Example Docs', text: '# Example Docs\n\nUseful Firecrawl extracted content.' },
+      metadata: { method: 'firecrawl', cacheHit: false }
+    });
+  });
+
+  it('returns needs_headless when Firecrawl succeeds without useful text', async () => {
+    const fetcher = createFirecrawlFetcher({
+      baseUrl: 'http://localhost:3002',
+      fetchImpl: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: { markdown: '   ', metadata: {} } })
+      } as Response)
+    });
+
+    await expect(fetcher('https://example.com/app')).resolves.toMatchObject({
+      status: 'needs_headless',
+      metadata: { method: 'firecrawl', cacheHit: false },
+      error: { code: 'WEAK_EXTRACTION' }
+    });
+  });
+});

--- a/tests/orchestration/research-workflow.test.ts
+++ b/tests/orchestration/research-workflow.test.ts
@@ -1,7 +1,43 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createResearchWorkflow } from '../../src/orchestration/index.js';
 
 describe('research workflow composition', () => {
+  it('can compose from backend config defaults', async () => {
+    vi.resetModules();
+    vi.doMock('../../src/backends/factory.js', () => ({
+      createBackendSet: vi.fn(() => ({
+        search: async () => ({
+          status: 'ok',
+          results: [],
+          metadata: { backend: 'duckduckgo', cacheHit: false }
+        }),
+        fetchPage: async () => ({
+          status: 'unsupported',
+          url: 'https://example.com',
+          metadata: { method: 'http', cacheHit: false, contentType: 'text/html' }
+        }),
+        headlessFetch: async () => ({
+          status: 'error',
+          url: 'https://example.com',
+          metadata: { method: 'headless', cacheHit: false },
+          error: { code: 'BROWSER_NOT_FOUND', message: 'No browser found.' }
+        })
+      }))
+    }));
+
+    const { createResearchWorkflow: createWorkflow } = await import('../../src/orchestration/index.js');
+    const workflow = createWorkflow({
+      backendConfig: {
+        search: { provider: 'duckduckgo' },
+        fetch: { provider: 'http' },
+        headless: { provider: 'local-browser' }
+      }
+    });
+
+    const result = await workflow.run({ query: 'example query' });
+    expect(result.decision.action).toBeDefined();
+  });
+
   it('can compose the orchestrator from existing search and fetch capabilities', async () => {
     const workflow = createResearchWorkflow({
       search: async () => ({

--- a/tests/presentation/config-store.test.ts
+++ b/tests/presentation/config-store.test.ts
@@ -38,6 +38,11 @@ describe('presentation config store', () => {
       defaultMode: 'compact',
       tools: {}
     });
+    expect(loaded.effectiveBackends).toEqual({
+      search: { provider: 'duckduckgo' },
+      fetch: { provider: 'http' },
+      headless: { provider: 'local-browser' }
+    });
     expect(loaded.global.exists).toBe(false);
     expect(loaded.project.exists).toBe(false);
   });
@@ -85,6 +90,63 @@ describe('presentation config store', () => {
         web_explore: { mode: 'verbose' },
         web_search: { mode: 'compact' }
       }
+    });
+  });
+
+  it('loads legacy presentation-only config files', async () => {
+    const { globalPath } = getPresentationConfigPaths({ homeDir, projectDir });
+    mkdirSync(path.dirname(globalPath), { recursive: true });
+    writeFileSync(
+      globalPath,
+      JSON.stringify({ defaultMode: 'preview', tools: { web_explore: { mode: 'verbose' } } }),
+      'utf8'
+    );
+
+    const loaded = await loadPresentationConfigLayers({ homeDir, projectDir });
+
+    expect(loaded.effectiveConfig).toEqual({
+      defaultMode: 'preview',
+      tools: { web_explore: { mode: 'verbose' } }
+    });
+  });
+
+  it('loads root presentation and backend config sections', async () => {
+    const { globalPath } = getPresentationConfigPaths({ homeDir, projectDir });
+    mkdirSync(path.dirname(globalPath), { recursive: true });
+    writeFileSync(
+      globalPath,
+      JSON.stringify({
+        presentation: { defaultMode: 'verbose' },
+        backends: { search: { provider: 'duckduckgo' } }
+      }),
+      'utf8'
+    );
+
+    const loaded = await loadPresentationConfigLayers({ homeDir, projectDir });
+
+    expect(loaded.effectiveConfig.defaultMode).toBe('verbose');
+    expect(loaded.effectiveBackends).toEqual({
+      search: { provider: 'duckduckgo' },
+      fetch: { provider: 'http' },
+      headless: { provider: 'local-browser' }
+    });
+  });
+
+  it('merges backend config layers with project taking precedence', async () => {
+    const { globalPath, projectPath } = getPresentationConfigPaths({ homeDir, projectDir });
+    mkdirSync(path.dirname(globalPath), { recursive: true });
+    mkdirSync(path.dirname(projectPath), { recursive: true });
+    writeFileSync(globalPath, JSON.stringify({ backends: { search: { provider: 'duckduckgo' } } }), 'utf8');
+    writeFileSync(projectPath, JSON.stringify({ backends: { fetch: { provider: 'http' } } }), 'utf8');
+
+    const loaded = await loadPresentationConfigLayers({ homeDir, projectDir });
+
+    expect(loaded.global.rawBackends).toEqual({ search: { provider: 'duckduckgo' } });
+    expect(loaded.project.rawBackends).toEqual({ fetch: { provider: 'http' } });
+    expect(loaded.effectiveBackends).toEqual({
+      search: { provider: 'duckduckgo' },
+      fetch: { provider: 'http' },
+      headless: { provider: 'local-browser' }
     });
   });
 

--- a/tests/presentation/config-store.test.ts
+++ b/tests/presentation/config-store.test.ts
@@ -117,7 +117,10 @@ describe('presentation config store', () => {
       globalPath,
       JSON.stringify({
         presentation: { defaultMode: 'verbose' },
-        backends: { search: { provider: 'duckduckgo' } }
+        backends: {
+          search: { provider: 'searxng', baseUrl: 'http://localhost:8080' },
+          fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', apiKey: 'dev-key' }
+        }
       }),
       'utf8'
     );
@@ -126,8 +129,8 @@ describe('presentation config store', () => {
 
     expect(loaded.effectiveConfig.defaultMode).toBe('verbose');
     expect(loaded.effectiveBackends).toEqual({
-      search: { provider: 'duckduckgo' },
-      fetch: { provider: 'http' },
+      search: { provider: 'searxng', baseUrl: 'http://localhost:8080' },
+      fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', apiKey: 'dev-key' },
       headless: { provider: 'local-browser' }
     });
   });

--- a/tests/search/searxng.test.ts
+++ b/tests/search/searxng.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSearxngSearchTool } from '../../src/search/searxng.js';
+
+describe('searxng search backend', () => {
+  it('maps SearXNG JSON results into web search results', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            title: 'Example Docs',
+            url: 'https://example.com/docs',
+            content: 'Useful docs snippet'
+          }
+        ]
+      })
+    } as Response);
+
+    const search = createSearxngSearchTool({ baseUrl: 'http://localhost:8080', fetchImpl });
+    const result = await search({ query: 'example docs' });
+
+    expect(fetchImpl).toHaveBeenCalledWith('http://localhost:8080/search?q=example+docs&format=json');
+    expect(result).toMatchObject({
+      status: 'ok',
+      results: [{ title: 'Example Docs', url: 'https://example.com/docs', snippet: 'Useful docs snippet' }],
+      metadata: { backend: 'searxng', cacheHit: false }
+    });
+  });
+
+  it('returns a useful error when SearXNG is unreachable', async () => {
+    const search = createSearxngSearchTool({
+      baseUrl: 'http://localhost:8080',
+      fetchImpl: vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED'))
+    });
+
+    await expect(search({ query: 'example' })).resolves.toMatchObject({
+      status: 'error',
+      metadata: { backend: 'searxng', cacheHit: false },
+      error: { code: 'FETCH_FAILED' }
+    });
+  });
+});


### PR DESCRIPTION
Adds backend config for web_explore so the default DuckDuckGo/http/local-browser path still works, but users can point search/fetch at existing SearXNG and Firecrawl instances.\n\nAlso added /web-agent show/doctor backend output, config validation, Firecrawl API key env support, self-hosted docs, and a changelog entry.\n\nChecked:\n- npm test\n- npm run lint\n- npm run build\n- npm run docs:build\n- node scripts/release.mjs --dry-run → v0.6.0