### PR TITLE
Pi 0.74 package scope migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is intentionally simple and release-oriented.
 ## Unreleased
 
 ### Added
-- Nothing yet.
+- Added one-time `pi-web-agent` changelog notices after package updates and `/web-agent changelog` for manual viewing.
 
 ### Changed
 - Migrated Pi package imports to `@earendil-works/*` after the upstream Pi scope move.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ The format is intentionally simple and release-oriented.
 - Nothing yet.
 
 ### Changed
-- Nothing yet.
+- Migrated Pi package imports to `@earendil-works/*` after the upstream Pi scope move.
 
 ### Fixed
 - Nothing yet.
 
 ### Breaking
-- None.
+- This release requires Pi 0.74+. Users on older Pi versions should stay on `@demigodmode/pi-web-agent@0.6.x` until they update Pi.
 
 ## [0.6.0] - 2026-05-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Helper commands:
 ```text
 /web-agent doctor
 /web-agent show
+/web-agent changelog
 /web-agent reset project
 /web-agent reset global
 /web-agent mode preview

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ That sounds obvious, but a lot of agent tooling gets fuzzy right there. This pac
 
 ## Install
 
+Compatibility notice: current `pi-web-agent` requires Pi 0.74+ because Pi packages moved to the `@earendil-works/*` scope. Update Pi before updating this package. If you are on an older Pi version, stay on `@demigodmode/pi-web-agent@0.6.x` until Pi is updated.
+
 ```bash
 pi install npm:@demigodmode/pi-web-agent
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "typebox": "^1.1.37"
       },
       "devDependencies": {
-        "@mariozechner/pi-coding-agent": "^0.69.0",
+        "@earendil-works/pi-coding-agent": "^0.74.0",
+        "@earendil-works/pi-tui": "^0.74.0",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^24.0.0",
         "@vitest/coverage-v8": "^3.2.4",
@@ -25,7 +26,8 @@
         "vitest": "^3.2.0"
       },
       "peerDependencies": {
-        "@mariozechner/pi-coding-agent": "*"
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -296,27 +298,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1344,6 +1325,140 @@
         }
       }
     },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+      "integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.74.0",
+        "typebox": "^1.1.24"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+      "integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "^2.2.0",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.0.tgz",
+      "integrity": "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.74.0",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-tui": "^0.74.0",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.5"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+      "integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1881,7 +1996,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.2",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
+      "integrity": "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1901,6 +2018,156 @@
         "@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
       }
     },
+    "node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+      "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+      "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+      "integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+      "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+      "integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
       "version": "0.3.2",
       "cpu": [
@@ -1914,117 +2181,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.69.0.tgz",
-      "integrity": "sha512-dYZjee7QEIwVVbDGCGriiLjDT34IdMlXMjMp4drVKcLEuVc+BztyODwu3w4ZORVvwaySGGlF9UALjJKUVoXiug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/pi-ai": "^0.69.0",
-        "typebox": "^1.1.24"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.69.0.tgz",
-      "integrity": "sha512-bl838sr57zx/apkiTeNPFQgbBkGXN4HHhm2oghzSRohJIBrR+H001bTeco7Osuke+EZTxO3V5Aev2qlZdUa2xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "^2.2.0",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.69.0.tgz",
-      "integrity": "sha512-/EFn43RO2TtMgZI4fMXNepIvbWm2GqhhaLIHBkrO7tRbRCzgvDYkw9sMLKhdf1Ihom2CjC3T/fzQRIPasRSIrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.69.0",
-        "@mariozechner/pi-ai": "^0.69.0",
-        "@mariozechner/pi-tui": "^0.69.0",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "chalk": "^5.5.0",
-        "cli-highlight": "^2.1.11",
-        "diff": "^8.0.2",
-        "extract-zip": "^2.0.1",
-        "file-type": "^21.1.1",
-        "glob": "^13.0.1",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "marked": "^15.0.12",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "strip-ansi": "^7.1.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "uuid": "^11.1.0",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.2"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.69.0.tgz",
-      "integrity": "sha512-/82SOMzCA1srivwfcSO8r9XLdAgJNcgpWzNZY33IqqvGev8Q4iWY/hA1wAkLB0l7PKJJ4Dh57xS4IGHbyVM7lA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime-types": "^2.1.4",
-        "chalk": "^5.5.0",
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12",
-        "mime-types": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
       }
     },
     "node_modules/@mistralai/mistralai": {
@@ -4974,6 +5130,16 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "dev": true,
@@ -6621,18 +6787,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -7123,17 +7277,6 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "typebox": "^1.1.37"
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.69.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^3.2.4",
@@ -69,6 +70,7 @@
     "vitest": "^3.2.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "keywords": [
     "pi-package",

--- a/scripts/live-web-eval.ts
+++ b/scripts/live-web-eval.ts
@@ -7,7 +7,7 @@ import {
   createAgentSession,
   ModelRegistry,
   SessionManager
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 import { createWebSearchTool } from '../src/tools/web-search.js';
 
 type PromptCase = {

--- a/src/changelog-notice.ts
+++ b/src/changelog-notice.ts
@@ -1,0 +1,133 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type ChangelogEntry = {
+  version: string;
+  content: string;
+};
+
+type ChangelogState = {
+  lastChangelogVersion?: string;
+};
+
+type ChangelogOptions = {
+  packageRoot?: string;
+  statePath?: string;
+};
+
+export function parseChangelogEntries(changelog: string): ChangelogEntry[] {
+  const lines = changelog.split(/\r?\n/);
+  const entries: ChangelogEntry[] = [];
+  let currentVersion: string | undefined;
+  let currentLines: string[] = [];
+
+  function flush() {
+    if (currentVersion && currentLines.length > 0) {
+      entries.push({ version: currentVersion, content: currentLines.join('\n').trim() });
+    }
+  }
+
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      flush();
+      const match = line.match(/^##\s+\[?(\d+\.\d+\.\d+)\]?/);
+      currentVersion = match?.[1];
+      currentLines = currentVersion ? [line] : [];
+      continue;
+    }
+
+    if (currentVersion) {
+      currentLines.push(line);
+    }
+  }
+
+  flush();
+  return entries;
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+
+  for (let i = 0; i < 3; i += 1) {
+    const diff = (leftParts[i] || 0) - (rightParts[i] || 0);
+    if (diff !== 0) return diff;
+  }
+
+  return 0;
+}
+
+function defaultPackageRoot() {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.basename(here) === 'dist' ? path.dirname(here) : path.dirname(here);
+}
+
+function defaultStatePath() {
+  const homeDir = process.env.USERPROFILE ?? process.env.HOME ?? '';
+  return path.join(homeDir, '.pi', 'agent', 'extensions', 'pi-web-agent', 'state.json');
+}
+
+async function readPackageVersion(packageRoot: string): Promise<string | undefined> {
+  try {
+    const raw = await readFile(path.join(packageRoot, 'package.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    return typeof parsed.version === 'string' ? parsed.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readChangelogEntries(packageRoot: string): Promise<ChangelogEntry[]> {
+  try {
+    return parseChangelogEntries(await readFile(path.join(packageRoot, 'CHANGELOG.md'), 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+async function readState(statePath: string): Promise<ChangelogState> {
+  try {
+    return JSON.parse(await readFile(statePath, 'utf8')) as ChangelogState;
+  } catch {
+    return {};
+  }
+}
+
+export async function markChangelogSeen({ statePath = defaultStatePath(), version }: { statePath?: string; version: string }) {
+  try {
+    await mkdir(path.dirname(statePath), { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastChangelogVersion: version }, null, 2)}\n`, 'utf8');
+  } catch {
+    // Changelog display is best effort. Never block extension startup on state persistence.
+  }
+}
+
+export async function getUpdateChangelogNotice(options: ChangelogOptions = {}): Promise<string | undefined> {
+  const packageRoot = options.packageRoot ?? defaultPackageRoot();
+  const statePath = options.statePath ?? defaultStatePath();
+  const version = await readPackageVersion(packageRoot);
+  if (!version) return undefined;
+
+  const state = await readState(statePath);
+  if (!state.lastChangelogVersion) {
+    await markChangelogSeen({ statePath, version });
+    return undefined;
+  }
+
+  if (compareVersions(version, state.lastChangelogVersion) <= 0) {
+    return undefined;
+  }
+
+  const entries = (await readChangelogEntries(packageRoot))
+    .filter((entry) => compareVersions(entry.version, state.lastChangelogVersion || '0.0.0') > 0)
+    .map((entry) => entry.content);
+
+  await markChangelogSeen({ statePath, version });
+  return entries.length > 0 ? entries.join('\n\n') : undefined;
+}
+
+export async function getLatestChangelogEntry(options: ChangelogOptions = {}): Promise<string | undefined> {
+  const entries = await readChangelogEntries(options.packageRoot ?? defaultPackageRoot());
+  return entries[0]?.content;
+}

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -4,8 +4,8 @@ import {
   DynamicBorder,
   getSettingsListTheme,
   type ExtensionAPI
-} from '@mariozechner/pi-coding-agent';
-import { Container, SelectList, SettingsList, Text, type SelectItem, type SettingItem } from '@mariozechner/pi-tui';
+} from '@earendil-works/pi-coding-agent';
+import { Container, SelectList, SettingsList, Text, type SelectItem, type SettingItem } from '@earendil-works/pi-tui';
 import {
   DEFAULT_PRESENTATION_CONFIG,
   mergePresentationConfigLayers,

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -18,6 +18,7 @@ import {
   type LoadedPresentationConfig
 } from '../presentation/config-store.js';
 import { resolveBrowserExecutable, type BrowserResolutionResult } from '../fetch/browser-resolution.js';
+import { getLatestChangelogEntry } from '../changelog-notice.js';
 import type {
   PresentationConfig,
   PresentationConfigOverride,
@@ -33,6 +34,7 @@ type CommandDeps = {
   runtime?: { nodeVersion: string; platform: string; arch: string };
   checkTypebox?: () => Promise<boolean>;
   checkBackends?: (config: BackendConfig) => Promise<string[]>;
+  getChangelog?: () => Promise<string | undefined>;
 };
 
 type SettingsUiResult =
@@ -384,6 +386,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
   };
   const checkTypebox = deps.checkTypebox ?? defaultCheckTypebox;
   const checkBackends = deps.checkBackends ?? ((config: BackendConfig) => checkBackendHealth(config));
+  const getChangelog = deps.getChangelog ?? (() => getLatestChangelogEntry());
 
   pi.registerCommand('web-agent', {
     description: 'Open settings or manage pi-web-agent presentation config',
@@ -442,6 +445,12 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
           ].join('\n'),
           'info'
         );
+        return;
+      }
+
+      if (action === 'changelog') {
+        const changelog = await getChangelog();
+        ctx.ui.notify(changelog ?? 'No pi-web-agent changelog entries found.', 'info');
         return;
       }
 
@@ -516,7 +525,7 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
       }
 
       ctx.ui.notify(
-        'Use /web-agent, /web-agent show, /web-agent doctor, /web-agent reset project, or /web-agent settings',
+        'Use /web-agent, /web-agent show, /web-agent doctor, /web-agent changelog, /web-agent reset project, or /web-agent settings',
         'info'
       );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { DEFAULT_BACKEND_CONFIG, type BackendConfig } from './backends/config.js';
 import { Type } from 'typebox';
 import { registerWebAgentConfigCommands } from './commands/web-agent-config.js';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import type {
 } from './presentation/types.js';
 import { createWebExploreTool } from './tools/web-explore.js';
 import type { WebExploreResponse } from './types.js';
+import { getUpdateChangelogNotice } from './changelog-notice.js';
 
 type ToolResultWithPresentation = {
   presentation?: PresentationEnvelope;
@@ -79,6 +80,17 @@ export default function extension(pi: ExtensionAPI) {
 
     return cachedWebExplore;
   }
+
+  pi.on('session_start', async (_event, ctx) => {
+    try {
+      const notice = await getUpdateChangelogNotice();
+      if (notice) {
+        ctx.ui.notify(`pi-web-agent updated\n\n${notice}`, 'info');
+      }
+    } catch {
+      // Never block extension startup on changelog display.
+    }
+  });
 
   pi.on('before_agent_start', async (event) => ({
     systemPrompt:

--- a/tests/changelog-notice.test.ts
+++ b/tests/changelog-notice.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  getLatestChangelogEntry,
+  getUpdateChangelogNotice,
+  markChangelogSeen,
+  parseChangelogEntries
+} from '../src/changelog-notice.js';
+
+async function makePackage(version = '1.0.0', changelog = `# Changelog\n\n## [1.0.0] - 2026-05-08\n### Breaking\n- This release requires Pi 0.74+.\n\n## [0.6.0] - 2026-05-04\n### Fixed\n- Old fix.\n`) {
+  const root = await mkdtemp(path.join(tmpdir(), 'pi-web-agent-changelog-'));
+  await writeFile(path.join(root, 'package.json'), JSON.stringify({ name: '@demigodmode/pi-web-agent', version }), 'utf8');
+  await writeFile(path.join(root, 'CHANGELOG.md'), changelog, 'utf8');
+  return root;
+}
+
+describe('changelog notice', () => {
+  it('parses version sections from changelog text', () => {
+    const entries = parseChangelogEntries(`# Changelog\n\n## Unreleased\n\n### Changed\n- Draft.\n\n## [1.0.0] - 2026-05-08\n### Breaking\n- Requires Pi 0.74+.\n\n## [0.6.0] - 2026-05-04\n### Fixed\n- Prior fix.\n`);
+
+    expect(entries).toEqual([
+      { version: '1.0.0', content: '## [1.0.0] - 2026-05-08\n### Breaking\n- Requires Pi 0.74+.' },
+      { version: '0.6.0', content: '## [0.6.0] - 2026-05-04\n### Fixed\n- Prior fix.' }
+    ]);
+  });
+
+  it('suppresses startup notice on first run and records the current version', async () => {
+    const packageRoot = await makePackage('1.0.0');
+    const statePath = path.join(await mkdtemp(path.join(tmpdir(), 'pi-web-agent-state-')), 'state.json');
+
+    await expect(getUpdateChangelogNotice({ packageRoot, statePath })).resolves.toBeUndefined();
+    await expect(readFile(statePath, 'utf8')).resolves.toContain('"lastChangelogVersion": "1.0.0"');
+  });
+
+  it('shows newer changelog entries once after update', async () => {
+    const packageRoot = await makePackage('1.0.0');
+    const statePath = path.join(await mkdtemp(path.join(tmpdir(), 'pi-web-agent-state-')), 'state.json');
+    await writeFile(statePath, JSON.stringify({ lastChangelogVersion: '0.6.0' }), 'utf8');
+
+    const notice = await getUpdateChangelogNotice({ packageRoot, statePath });
+
+    expect(notice).toContain('## [1.0.0] - 2026-05-08');
+    expect(notice).toContain('This release requires Pi 0.74+.');
+    expect(await getUpdateChangelogNotice({ packageRoot, statePath })).toBeUndefined();
+  });
+
+  it('returns latest changelog entry for manual display without changing state', async () => {
+    const packageRoot = await makePackage('1.0.0');
+
+    await expect(getLatestChangelogEntry({ packageRoot })).resolves.toContain('## [1.0.0] - 2026-05-08');
+  });
+
+  it('fails closed when package files are missing or malformed', async () => {
+    const packageRoot = await mkdtemp(path.join(tmpdir(), 'pi-web-agent-broken-'));
+    const statePath = path.join(packageRoot, 'state.json');
+
+    await expect(getUpdateChangelogNotice({ packageRoot, statePath })).resolves.toBeUndefined();
+    await expect(getLatestChangelogEntry({ packageRoot })).resolves.toBeUndefined();
+    await expect(markChangelogSeen({ statePath, version: '1.0.0' })).resolves.toBeUndefined();
+  });
+});

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -240,6 +240,24 @@ describe('web-agent config commands', () => {
     expect(notify.mock.calls[0][0]).not.toContain('web_fetch:');
   });
 
+  it('shows the latest changelog entry on request', async () => {
+    let handler: any;
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      getChangelog: vi.fn().mockResolvedValue('## [1.0.0]\n- Requires Pi 0.74+.')
+    });
+
+    const notify = vi.fn();
+    await handler('changelog', { ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Requires Pi 0.74+'), 'info');
+  });
+
   it('resets project scope when explicitly requested', async () => {
     let handler: any;
     const reset = vi.fn();

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -7,6 +7,7 @@ import {
   registerWebAgentConfigCommands
 } from '../../src/commands/web-agent-config.js';
 import { DEFAULT_PRESENTATION_CONFIG, mergePresentationConfigLayers } from '../../src/presentation/config.js';
+import { DEFAULT_BACKEND_CONFIG } from '../../src/backends/config.js';
 import type { BrowserResolutionResult } from '../../src/fetch/browser-resolution.js';
 
 describe('web-agent config draft helpers', () => {
@@ -114,6 +115,10 @@ describe('web-agent config commands', () => {
       resolveBrowser: vi.fn().mockResolvedValue(browser),
       runtime: { nodeVersion: 'v24.0.0', platform: 'linux', arch: 'x64' },
       checkTypebox: vi.fn().mockResolvedValue(true),
+      load: vi.fn().mockResolvedValue({
+        effectiveConfig: DEFAULT_PRESENTATION_CONFIG,
+        effectiveBackends: DEFAULT_BACKEND_CONFIG
+      }),
       checkBackends: vi.fn().mockResolvedValue(['search backend: duckduckgo', 'fetch backend: http'])
     });
 

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -82,6 +82,52 @@ describe('Pi extension entrypoint', () => {
     });
   });
 
+  it('shows update changelog notice on session start when available', async () => {
+    vi.resetModules();
+    const getUpdateChangelogNotice = vi.fn().mockResolvedValue('## [1.0.0]\n- Breaking change.');
+    vi.doMock('../src/changelog-notice.js', () => ({ getUpdateChangelogNotice, getLatestChangelogEntry: vi.fn() }));
+
+    const { default: dynamicExtension } = await import('../src/extension.js');
+    const handlers = new Map<string, Function>();
+    const notify = vi.fn();
+    const pi = {
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: Function) => {
+        handlers.set(eventName, handler);
+      })
+    };
+
+    dynamicExtension(pi as never);
+    await handlers.get('session_start')?.({ reason: 'startup' }, { ui: { notify } });
+
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('pi-web-agent updated'), 'info');
+    expect(notify.mock.calls[0][0]).toContain('Breaking change.');
+  });
+
+  it('does not fail startup when changelog notice loading fails', async () => {
+    vi.resetModules();
+    vi.doMock('../src/changelog-notice.js', () => ({
+      getUpdateChangelogNotice: vi.fn().mockRejectedValue(new Error('missing changelog')),
+      getLatestChangelogEntry: vi.fn()
+    }));
+
+    const { default: dynamicExtension } = await import('../src/extension.js');
+    const handlers = new Map<string, Function>();
+    const notify = vi.fn();
+    const pi = {
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+      on: vi.fn((eventName: string, handler: Function) => {
+        handlers.set(eventName, handler);
+      })
+    };
+
+    dynamicExtension(pi as never);
+    await expect(handlers.get('session_start')?.({ reason: 'startup' }, { ui: { notify } })).resolves.toBeUndefined();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
   it('registers the web-agent config commands', () => {
     const pi = {
       registerTool: vi.fn(),

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -44,6 +44,6 @@ describe('package manifest', () => {
         import: './dist/extension.js'
       }
     });
-    expect(packageJson.files).toEqual(['dist', 'README.md']);
+    expect(packageJson.files).toEqual(['dist', 'README.md', 'CHANGELOG.md']);
   });
 });

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -25,6 +25,16 @@ describe('package manifest', () => {
     expect(packageJson.peerDependencies?.['@sinclair/typebox']).toBeUndefined();
   });
 
+  it('declares the migrated pi package scope only', () => {
+    expect(packageJson.peerDependencies).toMatchObject({
+      '@earendil-works/pi-coding-agent': '*',
+      '@earendil-works/pi-tui': '*'
+    });
+    expect(packageJson.peerDependencies?.['@mariozechner/pi-coding-agent']).toBeUndefined();
+    expect(packageJson.peerDependencies?.['@mariozechner/pi-tui']).toBeUndefined();
+    expect(packageJson.peerDependenciesMeta).toBeUndefined();
+  });
+
   it('declares a clean package surface', () => {
     expect(packageJson.main).toBe('./dist/extension.js');
     expect(packageJson.types).toBe('./dist/extension.d.ts');

--- a/tests/pi-scope-migration-notice.test.ts
+++ b/tests/pi-scope-migration-notice.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+
+function readProjectFile(file: string) {
+  return readFileSync(path.join(root, file), 'utf8');
+}
+
+describe('pi scope migration notice', () => {
+  it('documents the Pi 0.74+ requirement in the README install section', () => {
+    const readme = readProjectFile('README.md');
+
+    expect(readme).toContain('requires Pi 0.74+');
+    expect(readme).toContain('Update Pi before updating this package');
+  });
+
+  it('records the breaking scope migration in the changelog', () => {
+    const changelog = readProjectFile('CHANGELOG.md');
+
+    expect(changelog).toContain('Migrated Pi package imports to `@earendil-works/*`');
+    expect(changelog).toContain('This release requires Pi 0.74+');
+  });
+});


### PR DESCRIPTION
Moves pi-web-agent over to the new @earendil-works Pi packages for Pi 0.74+. This intentionally drops support for old Pi installs; users on older Pi should stay on 0.6.x.

Also added a tiny changelog notice path and /web-agent changelog so release notes are available from inside Pi.