### PR TITLE
Add backend settings UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is intentionally simple and release-oriented.
 ## Unreleased
 
 ### Added
-- Nothing yet.
+- Added backend provider and fallback editing to `/web-agent settings`.
+- Added interactive URL prompts for SearXNG and Firecrawl backend setup.
 
 ### Changed
 - Nothing yet.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,17 @@ Example:
 }
 ```
 
-Backend config is also supported. Defaults remain DuckDuckGo search, plain HTTP fetch, and local browser headless fallback. If you already run SearXNG or Firecrawl, see the self-hosted backend guide:
+Backend config is also supported. Defaults remain DuckDuckGo search, plain HTTP fetch, and local browser headless fallback.
+
+Backend settings can be changed from:
+
+```text
+/web-agent settings
+```
+
+Choose **Backends** to edit search/fetch providers, fallback behavior, and SearXNG or Firecrawl base URLs interactively. Firecrawl API keys should stay in environment variables rather than being written into config files.
+
+If you already run SearXNG or Firecrawl, see the self-hosted backend guide:
 
 - https://demigodmode.github.io/pi-web-agent/self-hosted-backends
 

--- a/src/commands/web-agent-config.ts
+++ b/src/commands/web-agent-config.ts
@@ -1,4 +1,10 @@
-import { DEFAULT_BACKEND_CONFIG, validateBackendConfig, type BackendConfig } from '../backends/config.js';
+import {
+  DEFAULT_BACKEND_CONFIG,
+  mergeBackendConfigLayers,
+  validateBackendConfig,
+  type BackendConfig,
+  type BackendConfigOverride
+} from '../backends/config.js';
 import { checkBackendHealth } from '../backends/doctor.js';
 import {
   DynamicBorder,
@@ -14,6 +20,7 @@ import {
 import {
   loadPresentationConfigLayers,
   resetPresentationConfigScope,
+  saveBackendConfigScope,
   savePresentationConfigScope,
   type LoadedPresentationConfig
 } from '../presentation/config-store.js';
@@ -29,6 +36,7 @@ import type {
 type CommandDeps = {
   load?: () => ReturnType<typeof loadPresentationConfigLayers>;
   save?: (scope: PresentationScope, config: PresentationConfigOverride) => Promise<void>;
+  saveBackends?: (scope: PresentationScope, config: BackendConfigOverride) => Promise<void>;
   reset?: (scope: PresentationScope) => Promise<void>;
   resolveBrowser?: () => Promise<BrowserResolutionResult>;
   runtime?: { nodeVersion: string; platform: string; arch: string };
@@ -40,14 +48,17 @@ type CommandDeps = {
 type SettingsUiResult =
   | { action: 'cancel' }
   | { action: 'reset'; scope: PresentationScope }
-  | { action: 'save'; scope: PresentationScope; config: PresentationConfig };
+  | { action: 'save'; scope: PresentationScope; config: PresentationConfig; backends: BackendConfig };
 
-type WebAgentAction = 'settings' | 'show' | 'doctor' | 'reset-project' | 'reset-global';
+type WebAgentAction = 'settings' | 'show' | 'doctor' | 'changelog' | 'reset-project' | 'reset-global';
+type SettingsSection = 'presentation' | 'backends';
 
 export type SettingsDraftState = {
   scope: PresentationScope;
   drafts: Record<PresentationScope, PresentationConfig>;
+  backendDrafts: Record<PresentationScope, BackendConfig>;
   config: PresentationConfig;
+  backends: BackendConfig;
 };
 
 const PRESENTATION_TOOL_NAMES: PresentationToolName[] = ['web_explore'];
@@ -61,6 +72,37 @@ function clonePresentationConfig(config: PresentationConfig): PresentationConfig
     defaultMode: config.defaultMode,
     tools: { ...config.tools }
   };
+}
+
+function cloneBackendConfig(config: BackendConfig): BackendConfig {
+  return {
+    search: {
+      ...config.search,
+      options: config.search.options ? { ...config.search.options } : undefined
+    },
+    fetch: {
+      ...config.fetch,
+      options: config.fetch.options ? { ...config.fetch.options } : undefined
+    },
+    headless: { ...config.headless }
+  };
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function validateBackendUrl(value: string): { ok: true; value: string } | { ok: false; message: string } {
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return { ok: false, message: 'Invalid URL. Include http:// or https://.' };
+    }
+
+    return { ok: true, value: url.toString().replace(/\/$/, '') };
+  } catch {
+    return { ok: false, message: 'Invalid URL. Include http:// or https://.' };
+  }
 }
 
 async function defaultCheckTypebox(): Promise<boolean> {
@@ -116,7 +158,7 @@ function formatConfigSummary(config: PresentationConfig) {
   return lines.join('\n');
 }
 
-function buildSettingsItems(scope: PresentationScope, config: PresentationConfig): SettingItem[] {
+function buildPresentationSettingsItems(scope: PresentationScope, config: PresentationConfig): SettingItem[] {
   return [
     {
       id: 'scope',
@@ -136,6 +178,59 @@ function buildSettingsItems(scope: PresentationScope, config: PresentationConfig
       currentValue: config.tools[toolName]?.mode ?? 'inherit',
       values: ['inherit', 'compact', 'preview', 'verbose']
     }))
+  ];
+}
+
+function buildBackendSettingsItems(scope: PresentationScope, backends: BackendConfig): SettingItem[] {
+  return [
+    {
+      id: 'scope',
+      label: 'Write scope',
+      currentValue: scope,
+      values: ['project', 'global']
+    },
+    {
+      id: 'backend:search:provider',
+      label: 'Search backend',
+      currentValue: backends.search.provider,
+      values: ['duckduckgo', 'searxng']
+    },
+    {
+      id: 'backend:search:baseUrl',
+      label: 'SearXNG URL',
+      currentValue: backends.search.baseUrl ?? 'not set',
+      values: ['edit']
+    },
+    {
+      id: 'backend:search:fallback',
+      label: 'SearXNG fallback',
+      currentValue: backends.search.provider === 'searxng' ? backends.search.fallback ?? 'off' : 'off',
+      values: backends.search.provider === 'searxng' ? ['off', 'duckduckgo'] : ['off']
+    },
+    {
+      id: 'backend:fetch:provider',
+      label: 'Fetch backend',
+      currentValue: backends.fetch.provider,
+      values: ['http', 'firecrawl']
+    },
+    {
+      id: 'backend:fetch:baseUrl',
+      label: 'Firecrawl URL',
+      currentValue: backends.fetch.baseUrl ?? 'not set',
+      values: ['edit']
+    },
+    {
+      id: 'backend:fetch:fallback',
+      label: 'Firecrawl fallback',
+      currentValue: backends.fetch.provider === 'firecrawl' ? backends.fetch.fallback ?? 'off' : 'off',
+      values: backends.fetch.provider === 'firecrawl' ? ['off', 'http'] : ['off']
+    },
+    {
+      id: 'backend:secret:firecrawl',
+      label: 'Firecrawl API key',
+      currentValue: 'env var',
+      values: ['env var']
+    }
   ];
 }
 
@@ -173,6 +268,32 @@ export function getScopeDisplayConfig(
   );
 }
 
+export function getInheritedBackendsForScope(
+  loaded: Awaited<LoadedPresentationConfig>,
+  scope: PresentationScope
+): BackendConfig {
+  if (scope === 'global') {
+    return DEFAULT_BACKEND_CONFIG;
+  }
+
+  return mergeBackendConfigLayers(DEFAULT_BACKEND_CONFIG, loaded.global.rawBackends);
+}
+
+export function getScopeDisplayBackends(
+  loaded: Awaited<LoadedPresentationConfig>,
+  scope: PresentationScope
+): BackendConfig {
+  if (scope === 'global') {
+    return mergeBackendConfigLayers(DEFAULT_BACKEND_CONFIG, loaded.global.rawBackends);
+  }
+
+  return mergeBackendConfigLayers(
+    DEFAULT_BACKEND_CONFIG,
+    loaded.global.rawBackends,
+    loaded.project.rawBackends
+  );
+}
+
 export function createSettingsDraftState(
   loaded: Awaited<LoadedPresentationConfig>,
   initialScope: PresentationScope
@@ -181,11 +302,17 @@ export function createSettingsDraftState(
     global: getScopeDisplayConfig(loaded, 'global'),
     project: getScopeDisplayConfig(loaded, 'project')
   };
+  const backendDrafts = {
+    global: getScopeDisplayBackends(loaded, 'global'),
+    project: getScopeDisplayBackends(loaded, 'project')
+  };
 
   return {
     scope: initialScope,
     drafts,
-    config: clonePresentationConfig(drafts[initialScope])
+    backendDrafts,
+    config: clonePresentationConfig(drafts[initialScope]),
+    backends: cloneBackendConfig(backendDrafts[initialScope])
   };
 }
 
@@ -198,6 +325,10 @@ export function applySettingsValue(
     global: clonePresentationConfig(state.drafts.global),
     project: clonePresentationConfig(state.drafts.project)
   };
+  const nextBackendDrafts = {
+    global: cloneBackendConfig(state.backendDrafts.global),
+    project: cloneBackendConfig(state.backendDrafts.project)
+  };
 
   let nextScope = state.scope;
 
@@ -206,11 +337,14 @@ export function applySettingsValue(
     return {
       scope: nextScope,
       drafts: nextDrafts,
-      config: clonePresentationConfig(nextDrafts[nextScope])
+      backendDrafts: nextBackendDrafts,
+      config: clonePresentationConfig(nextDrafts[nextScope]),
+      backends: cloneBackendConfig(nextBackendDrafts[nextScope])
     };
   }
 
   const currentDraft = clonePresentationConfig(nextDrafts[nextScope]);
+  const currentBackends = cloneBackendConfig(nextBackendDrafts[nextScope]);
 
   if (id === 'defaultMode' && (newValue === 'compact' || newValue === 'preview' || newValue === 'verbose')) {
     currentDraft.defaultMode = newValue;
@@ -233,12 +367,61 @@ export function applySettingsValue(
     currentDraft.tools = nextTools;
   }
 
+  if (id === 'backend:search:provider' && (newValue === 'duckduckgo' || newValue === 'searxng')) {
+    currentBackends.search.provider = newValue;
+    if (newValue === 'duckduckgo') {
+      delete currentBackends.search.fallback;
+    }
+  }
+
+  if (id === 'backend:search:fallback') {
+    if (newValue === 'duckduckgo' && currentBackends.search.provider === 'searxng') {
+      currentBackends.search.fallback = 'duckduckgo';
+    } else if (newValue === 'off' || currentBackends.search.provider !== 'searxng') {
+      delete currentBackends.search.fallback;
+    }
+  }
+
+  if (id === 'backend:search:baseUrl') {
+    if (newValue.trim()) {
+      currentBackends.search.baseUrl = newValue.trim();
+    } else {
+      delete currentBackends.search.baseUrl;
+    }
+  }
+
+  if (id === 'backend:fetch:provider' && (newValue === 'http' || newValue === 'firecrawl')) {
+    currentBackends.fetch.provider = newValue;
+    if (newValue === 'http') {
+      delete currentBackends.fetch.fallback;
+    }
+  }
+
+  if (id === 'backend:fetch:fallback') {
+    if (newValue === 'http' && currentBackends.fetch.provider === 'firecrawl') {
+      currentBackends.fetch.fallback = 'http';
+    } else if (newValue === 'off' || currentBackends.fetch.provider !== 'firecrawl') {
+      delete currentBackends.fetch.fallback;
+    }
+  }
+
+  if (id === 'backend:fetch:baseUrl') {
+    if (newValue.trim()) {
+      currentBackends.fetch.baseUrl = newValue.trim();
+    } else {
+      delete currentBackends.fetch.baseUrl;
+    }
+  }
+
   nextDrafts[nextScope] = currentDraft;
+  nextBackendDrafts[nextScope] = currentBackends;
 
   return {
     scope: nextScope,
     drafts: nextDrafts,
-    config: clonePresentationConfig(nextDrafts[nextScope])
+    backendDrafts: nextBackendDrafts,
+    config: clonePresentationConfig(nextDrafts[nextScope]),
+    backends: cloneBackendConfig(nextBackendDrafts[nextScope])
   };
 }
 
@@ -269,6 +452,53 @@ export function collapsePresentationConfigToOverride(
   };
 }
 
+export function collapseBackendConfigToOverride(
+  config: BackendConfig,
+  inheritedConfig: BackendConfig
+): BackendConfigOverride {
+  const override: BackendConfigOverride = {};
+
+  if (!sameJson(config.search, inheritedConfig.search)) {
+    override.search = config.search.provider !== inheritedConfig.search.provider
+      ? { ...config.search }
+      : {
+          ...(config.search.baseUrl !== inheritedConfig.search.baseUrl ? { baseUrl: config.search.baseUrl } : {}),
+          ...(config.search.fallback !== inheritedConfig.search.fallback ? { fallback: config.search.fallback } : {}),
+          ...(!sameJson(config.search.options, inheritedConfig.search.options) ? { options: config.search.options } : {})
+        };
+
+    if (config.search.provider !== inheritedConfig.search.provider) {
+      override.search.provider = config.search.provider;
+    } else if (Object.keys(override.search).length === 0) {
+      delete override.search;
+    }
+  }
+
+  if (!sameJson(config.fetch, inheritedConfig.fetch)) {
+    override.fetch = config.fetch.provider !== inheritedConfig.fetch.provider
+      ? { ...config.fetch, apiKey: undefined }
+      : {
+          ...(config.fetch.baseUrl !== inheritedConfig.fetch.baseUrl ? { baseUrl: config.fetch.baseUrl } : {}),
+          ...(config.fetch.fallback !== inheritedConfig.fetch.fallback ? { fallback: config.fetch.fallback } : {}),
+          ...(!sameJson(config.fetch.options, inheritedConfig.fetch.options) ? { options: config.fetch.options } : {})
+        };
+
+    delete override.fetch.apiKey;
+
+    if (config.fetch.provider !== inheritedConfig.fetch.provider) {
+      override.fetch.provider = config.fetch.provider;
+    } else if (Object.keys(override.fetch).length === 0) {
+      delete override.fetch;
+    }
+  }
+
+  if (!sameJson(config.headless, inheritedConfig.headless)) {
+    override.headless = { ...config.headless };
+  }
+
+  return override;
+}
+
 export function handleSettingsShortcut(data: string): { action: 'cancel' | 'reset' | 'save' } | undefined {
   if (data === '\u001b') {
     return { action: 'cancel' };
@@ -289,9 +519,10 @@ async function openActionMenu(ctx: any): Promise<WebAgentAction | undefined> {
   return ctx.ui.custom((tui: any, theme: any, _kb: unknown, done: (value: WebAgentAction | undefined) => void) => {
     const container = new Container();
     const items: SelectItem[] = [
-      { value: 'settings', label: 'Settings', description: 'Edit presentation modes' },
+      { value: 'settings', label: 'Settings', description: 'Edit presentation modes and backends' },
       { value: 'show', label: 'Show config', description: 'Print effective config paths and modes' },
       { value: 'doctor', label: 'Doctor', description: 'Check runtime dependencies and browser detection' },
+      { value: 'changelog', label: 'Changelog', description: 'Show latest package changelog' },
       { value: 'reset-project', label: 'Reset project config', description: 'Delete project-level overrides' },
       { value: 'reset-global', label: 'Reset global config', description: 'Delete global overrides' }
     ];
@@ -324,7 +555,43 @@ async function openActionMenu(ctx: any): Promise<WebAgentAction | undefined> {
   });
 }
 
-async function openSettingsUi(
+async function openSettingsSectionMenu(ctx: any): Promise<SettingsSection | undefined> {
+  return ctx.ui.custom((tui: any, theme: any, _kb: unknown, done: (value: SettingsSection | undefined) => void) => {
+    const container = new Container();
+    const items: SelectItem[] = [
+      { value: 'presentation', label: 'Presentation', description: 'Compact, preview, and verbose output modes' },
+      { value: 'backends', label: 'Backends', description: 'Search/fetch providers, URLs, and fallbacks' }
+    ];
+
+    container.addChild(new DynamicBorder((text: string) => theme.fg('accent', text)));
+    container.addChild(new Text(theme.fg('accent', theme.bold('pi-web-agent settings')), 1, 0));
+
+    const list = new SelectList(items, items.length, {
+      selectedPrefix: (text: string) => theme.fg('accent', text),
+      selectedText: (text: string) => theme.fg('accent', text),
+      description: (text: string) => theme.fg('muted', text),
+      scrollInfo: (text: string) => theme.fg('dim', text),
+      noMatch: (text: string) => theme.fg('warning', text)
+    });
+
+    list.onSelect = (item) => done(item.value as SettingsSection);
+    list.onCancel = () => done(undefined);
+    container.addChild(list);
+    container.addChild(new Text(theme.fg('dim', '↑↓ navigate • enter select • esc cancel'), 1, 0));
+    container.addChild(new DynamicBorder((text: string) => theme.fg('accent', text)));
+
+    return {
+      render: (width: number) => container.render(width),
+      invalidate: () => container.invalidate(),
+      handleInput: (data: string) => {
+        list.handleInput?.(data);
+        tui.requestRender?.();
+      }
+    };
+  });
+}
+
+async function openPresentationSettingsUi(
   ctx: any,
   loaded: Awaited<LoadedPresentationConfig>,
   initialScope: PresentationScope
@@ -334,7 +601,7 @@ async function openSettingsUi(
     let settingsList: SettingsList;
 
     const container = new Container();
-    container.addChild(new Text(theme.fg('accent', theme.bold('pi-web-agent settings')), 1, 1));
+    container.addChild(new Text(theme.fg('accent', theme.bold('pi-web-agent · presentation')), 1, 1));
     container.addChild(
       new Text(
         theme.fg('muted', 'Ctrl+S save · Ctrl+R reset scope · Esc cancel'),
@@ -349,7 +616,7 @@ async function openSettingsUi(
       }
 
       settingsList = new SettingsList(
-        buildSettingsItems(state.scope, state.config),
+        buildPresentationSettingsItems(state.scope, state.config),
         Math.min(PRESENTATION_TOOL_NAMES.length + 8, 18),
         getSettingsListTheme(),
         (id, newValue) => {
@@ -357,7 +624,7 @@ async function openSettingsUi(
           rebuildSettingsList();
           container.invalidate();
         },
-        () => done({ action: 'save', scope: state.scope, config: state.config }),
+        () => done({ action: 'save', scope: state.scope, config: state.config, backends: state.backends }),
         { enableSearch: true }
       );
 
@@ -383,7 +650,106 @@ async function openSettingsUi(
         }
 
         if (shortcut?.action === 'save') {
-          done({ action: 'save', scope: state.scope, config: state.config });
+          done({ action: 'save', scope: state.scope, config: state.config, backends: state.backends });
+          return;
+        }
+
+        settingsList.handleInput?.(data);
+      }
+    };
+  });
+}
+
+async function openBackendSettingsUi(
+  ctx: any,
+  loaded: Awaited<LoadedPresentationConfig>,
+  initialScope: PresentationScope
+): Promise<SettingsUiResult | undefined> {
+  return ctx.ui.custom((tui: any, theme: any, _kb: unknown, done: (value: SettingsUiResult) => void) => {
+    let state = createSettingsDraftState(loaded, initialScope);
+    let settingsList: SettingsList;
+
+    const container = new Container();
+    container.addChild(new Text(theme.fg('accent', theme.bold('pi-web-agent · backends')), 1, 1));
+    container.addChild(
+      new Text(
+        theme.fg('muted', 'Ctrl+S save · Ctrl+R reset scope · Esc cancel · API keys stay in env vars'),
+        1,
+        2
+      )
+    );
+
+    const editUrl = async (id: string) => {
+      const isSearchUrl = id === 'backend:search:baseUrl';
+      const label = isSearchUrl ? 'SearXNG base URL' : 'Firecrawl base URL';
+      const currentValue = isSearchUrl ? state.backends.search.baseUrl : state.backends.fetch.baseUrl;
+      const entered = await ctx.ui.input(label, currentValue ?? (isSearchUrl ? 'http://localhost:8080' : 'http://localhost:3002'));
+      if (entered === undefined) return;
+
+      if (!entered.trim()) {
+        state = applySettingsValue(state, id, '');
+        rebuildSettingsList();
+        tui.requestRender?.();
+        return;
+      }
+
+      const validated = validateBackendUrl(entered);
+      if (!validated.ok) {
+        ctx.ui.notify(validated.message, 'warning');
+        return;
+      }
+
+      state = applySettingsValue(state, id, validated.value);
+      rebuildSettingsList();
+      tui.requestRender?.();
+    };
+
+    const rebuildSettingsList = () => {
+      if (settingsList) {
+        container.removeChild(settingsList);
+      }
+
+      settingsList = new SettingsList(
+        buildBackendSettingsItems(state.scope, state.backends),
+        12,
+        getSettingsListTheme(),
+        (id, newValue) => {
+          if (id === 'backend:search:baseUrl' || id === 'backend:fetch:baseUrl') {
+            void editUrl(id);
+            return;
+          }
+
+          state = applySettingsValue(state, id, newValue);
+          rebuildSettingsList();
+          container.invalidate();
+        },
+        () => done({ action: 'save', scope: state.scope, config: state.config, backends: state.backends }),
+        { enableSearch: true }
+      );
+
+      container.addChild(settingsList);
+    };
+
+    rebuildSettingsList();
+
+    return {
+      render: (width: number) => container.render(width),
+      invalidate: () => container.invalidate(),
+      handleInput: (data: string) => {
+        const shortcut = handleSettingsShortcut(JSON.stringify(data).slice(1, -1));
+
+        if (shortcut?.action === 'cancel') {
+          done({ action: 'cancel' });
+          return;
+        }
+
+        if (shortcut?.action === 'reset') {
+          done({ action: 'reset', scope: state.scope });
+          return;
+        }
+
+        if (shortcut?.action === 'save') {
+          done({ action: 'save', scope: state.scope, config: state.config, backends: state.backends });
           return;
         }
 
@@ -396,6 +762,7 @@ async function openSettingsUi(
 export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDeps = {}) {
   const load = deps.load ?? (() => loadPresentationConfigLayers());
   const save = deps.save ?? ((scope, config) => savePresentationConfigScope({}, scope, config));
+  const saveBackends = deps.saveBackends ?? ((scope, config) => saveBackendConfigScope({}, scope, config));
   const reset = deps.reset ?? ((scope) => resetPresentationConfigScope({}, scope));
   const resolveBrowser = deps.resolveBrowser ?? (() => resolveBrowserExecutable({}));
   const runtime = deps.runtime ?? {
@@ -520,7 +887,12 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
       if (!action || action === 'settings') {
         const loaded = await load();
         const initialScope: PresentationScope = 'project';
-        const result = await openSettingsUi(ctx, loaded, initialScope);
+        const section = await openSettingsSectionMenu(ctx);
+        if (!section) return;
+
+        const result = section === 'presentation'
+          ? await openPresentationSettingsUi(ctx, loaded, initialScope)
+          : await openBackendSettingsUi(ctx, loaded, initialScope);
 
         if (!result || result.action === 'cancel') {
           return;
@@ -532,14 +904,26 @@ export function registerWebAgentConfigCommands(pi: ExtensionAPI, deps: CommandDe
           return;
         }
 
-        await save(
+        if (section === 'presentation') {
+          await save(
+            result.scope,
+            collapsePresentationConfigToOverride(
+              result.config,
+              getInheritedConfigForScope(loaded, result.scope)
+            )
+          );
+          ctx.ui.notify(`Saved ${result.scope} presentation config`, 'info');
+          return;
+        }
+
+        await saveBackends(
           result.scope,
-          collapsePresentationConfigToOverride(
-            result.config,
-            getInheritedConfigForScope(loaded, result.scope)
+          collapseBackendConfigToOverride(
+            result.backends,
+            getInheritedBackendsForScope(loaded, result.scope)
           )
         );
-        ctx.ui.notify(`Saved ${result.scope} config`, 'info');
+        ctx.ui.notify(`Saved ${result.scope} backend config`, 'info');
         return;
       }
 

--- a/src/presentation/config-store.ts
+++ b/src/presentation/config-store.ts
@@ -100,6 +100,42 @@ function serializePresentationConfigOverride(config: PresentationConfigOverride)
   return { presentation };
 }
 
+function serializeBackendConfigOverride(config: BackendConfigOverride): BackendConfigFile {
+  const backends: NonNullable<BackendConfigFile['backends']> = {};
+
+  if (config.search && Object.keys(config.search).length > 0) {
+    backends.search = { ...config.search };
+  }
+
+  if (config.fetch && Object.keys(config.fetch).length > 0) {
+    const { apiKey: _apiKey, ...fetch } = config.fetch;
+    backends.fetch = { ...fetch };
+  }
+
+  if (config.headless && Object.keys(config.headless).length > 0) {
+    backends.headless = { ...config.headless };
+  }
+
+  return { backends };
+}
+
+async function readConfigFileForWrite(filePath: string): Promise<AgentConfigFile> {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8')) as AgentConfigFile;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT') {
+      return {};
+    }
+
+    throw error;
+  }
+}
+
+async function writeConfigFile(filePath: string, config: AgentConfigFile) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+}
+
 export async function loadPresentationConfigLayers(
   options: PresentationConfigStoreOptions = {}
 ): Promise<LoadedPresentationConfig> {
@@ -130,13 +166,27 @@ export async function savePresentationConfigScope(
 ) {
   const { globalPath, projectPath } = getPresentationConfigPaths(options);
   const filePath = scope === 'global' ? globalPath : projectPath;
+  const existing = await readConfigFileForWrite(filePath);
 
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(
-    filePath,
-    JSON.stringify(serializePresentationConfigOverride(config), null, 2) + '\n',
-    'utf8'
-  );
+  await writeConfigFile(filePath, {
+    ...existing,
+    ...serializePresentationConfigOverride(config)
+  });
+}
+
+export async function saveBackendConfigScope(
+  options: PresentationConfigStoreOptions,
+  scope: PresentationScope,
+  config: BackendConfigOverride
+) {
+  const { globalPath, projectPath } = getPresentationConfigPaths(options);
+  const filePath = scope === 'global' ? globalPath : projectPath;
+  const existing = await readConfigFileForWrite(filePath);
+
+  await writeConfigFile(filePath, {
+    ...existing,
+    ...serializeBackendConfigOverride(config)
+  });
 }
 
 export async function resetPresentationConfigScope(

--- a/tests/commands/web-agent-config.test.ts
+++ b/tests/commands/web-agent-config.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   applySettingsValue,
+  collapseBackendConfigToOverride,
   collapsePresentationConfigToOverride,
   createSettingsDraftState,
   handleSettingsShortcut,
-  registerWebAgentConfigCommands
+  registerWebAgentConfigCommands,
+  validateBackendUrl
 } from '../../src/commands/web-agent-config.js';
 import { DEFAULT_PRESENTATION_CONFIG, mergePresentationConfigLayers } from '../../src/presentation/config.js';
 import { DEFAULT_BACKEND_CONFIG } from '../../src/backends/config.js';
@@ -75,6 +77,98 @@ describe('web-agent config draft helpers', () => {
     ).toEqual({
       tools: { web_explore: { mode: 'verbose' } }
     });
+  });
+
+  it('switches backend settings with the selected scope draft', () => {
+    const loaded = {
+      global: {
+        path: '/global/config.json',
+        exists: true,
+        rawConfig: { tools: {} },
+        rawBackends: {
+          search: { provider: 'searxng' as const, baseUrl: 'http://global-searxng', fallback: 'duckduckgo' as const },
+          fetch: { provider: 'http' as const }
+        }
+      },
+      project: {
+        path: '/project/config.json',
+        exists: true,
+        rawConfig: { tools: {} },
+        rawBackends: {
+          fetch: { provider: 'firecrawl' as const, baseUrl: 'http://project-firecrawl', fallback: 'http' as const }
+        }
+      },
+      effectiveConfig: DEFAULT_PRESENTATION_CONFIG,
+      effectiveBackends: {
+        search: { provider: 'searxng' as const, baseUrl: 'http://global-searxng', fallback: 'duckduckgo' as const },
+        fetch: { provider: 'firecrawl' as const, baseUrl: 'http://project-firecrawl', fallback: 'http' as const },
+        headless: { provider: 'local-browser' as const }
+      }
+    };
+
+    const initial = createSettingsDraftState(loaded, 'project');
+    expect(initial.backends.fetch.provider).toBe('firecrawl');
+
+    const switched = applySettingsValue(initial, 'scope', 'global');
+    expect(switched.backends.fetch.provider).toBe('http');
+  });
+
+  it('collapses backend values inherited from the parent scope', () => {
+    expect(
+      collapseBackendConfigToOverride(
+        {
+          search: { provider: 'searxng', baseUrl: 'http://localhost:8080', fallback: 'duckduckgo' },
+          fetch: { provider: 'http' },
+          headless: { provider: 'local-browser' }
+        },
+        {
+          search: { provider: 'searxng', baseUrl: 'http://localhost:8080', fallback: 'duckduckgo' },
+          fetch: { provider: 'http' },
+          headless: { provider: 'local-browser' }
+        }
+      )
+    ).toEqual({});
+  });
+
+  it('applies backend provider, fallback, and url draft values', () => {
+    const loaded = {
+      global: { path: '/global/config.json', exists: false },
+      project: { path: '/project/config.json', exists: false },
+      effectiveConfig: DEFAULT_PRESENTATION_CONFIG,
+      effectiveBackends: DEFAULT_BACKEND_CONFIG
+    };
+
+    const state = createSettingsDraftState(loaded, 'project');
+
+    const searchProviderState = applySettingsValue(state, 'backend:search:provider', 'searxng');
+    const fetchProviderState = applySettingsValue(state, 'backend:fetch:provider', 'firecrawl');
+
+    expect(searchProviderState.backends.search.provider).toBe('searxng');
+    expect(applySettingsValue(searchProviderState, 'backend:search:fallback', 'duckduckgo').backends.search.fallback).toBe('duckduckgo');
+    expect(fetchProviderState.backends.fetch.provider).toBe('firecrawl');
+    expect(applySettingsValue(fetchProviderState, 'backend:fetch:fallback', 'http').backends.fetch.fallback).toBe('http');
+    expect(applySettingsValue(state, 'backend:search:baseUrl', 'http://localhost:8080').backends.search.baseUrl).toBe('http://localhost:8080');
+    expect(applySettingsValue(state, 'backend:fetch:baseUrl', 'http://localhost:3002').backends.fetch.baseUrl).toBe('http://localhost:3002');
+  });
+
+  it('does not set fallback values for providers that do not support them', () => {
+    const loaded = {
+      global: { path: '/global/config.json', exists: false },
+      project: { path: '/project/config.json', exists: false },
+      effectiveConfig: DEFAULT_PRESENTATION_CONFIG,
+      effectiveBackends: DEFAULT_BACKEND_CONFIG
+    };
+
+    const state = createSettingsDraftState(loaded, 'project');
+
+    expect(applySettingsValue(state, 'backend:search:fallback', 'duckduckgo').backends.search.fallback).toBeUndefined();
+    expect(applySettingsValue(state, 'backend:fetch:fallback', 'http').backends.fetch.fallback).toBeUndefined();
+  });
+
+  it('validates backend urls for interactive prompts', () => {
+    expect(validateBackendUrl('localhost:8080')).toEqual({ ok: false, message: 'Invalid URL. Include http:// or https://.' });
+    expect(validateBackendUrl('ftp://localhost:8080')).toEqual({ ok: false, message: 'Invalid URL. Include http:// or https://.' });
+    expect(validateBackendUrl('http://localhost:8080')).toEqual({ ok: true, value: 'http://localhost:8080' });
   });
 
   it('supports real cancel and reset shortcuts in the settings UI', () => {
@@ -310,18 +404,20 @@ describe('web-agent config commands', () => {
     const custom = vi
       .fn()
       .mockResolvedValueOnce('settings')
+      .mockResolvedValueOnce('presentation')
       .mockResolvedValueOnce({
         scope: 'project',
         config: {
           defaultMode: 'preview',
           tools: { web_explore: { mode: 'verbose' } }
         },
+        backends: DEFAULT_BACKEND_CONFIG,
         action: 'save'
       });
 
     await handler('', { ui: { custom, notify: vi.fn() } });
 
-    expect(custom).toHaveBeenCalledTimes(2);
+    expect(custom).toHaveBeenCalledTimes(3);
   });
 
   it('runs doctor from the action menu', async () => {
@@ -367,18 +463,117 @@ describe('web-agent config commands', () => {
       reset: vi.fn()
     });
 
-    const custom = vi.fn().mockResolvedValue({
-      scope: 'project',
-      config: {
-        defaultMode: 'preview',
-        tools: { web_explore: { mode: 'verbose' } }
-      },
-      action: 'save'
-    });
+    const custom = vi
+      .fn()
+      .mockResolvedValueOnce('presentation')
+      .mockResolvedValueOnce({
+        scope: 'project',
+        config: {
+          defaultMode: 'preview',
+          tools: { web_explore: { mode: 'verbose' } }
+        },
+        backends: DEFAULT_BACKEND_CONFIG,
+        action: 'save'
+      });
 
     await handler('settings', { ui: { custom, notify: vi.fn() } });
 
-    expect(custom).toHaveBeenCalledOnce();
+    expect(custom).toHaveBeenCalledTimes(2);
+  });
+
+  it('saves only presentation overrides from the presentation settings section', async () => {
+    let handler: any;
+    const save = vi.fn();
+    const saveBackends = vi.fn();
+    const notify = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: { path: '/project/config.json', exists: false },
+        effectiveConfig: { defaultMode: 'compact', tools: {} },
+        effectiveBackends: {
+          search: { provider: 'searxng', baseUrl: 'http://localhost:8080', fallback: 'duckduckgo' },
+          fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', fallback: 'http' },
+          headless: { provider: 'local-browser' }
+        }
+      }),
+      save,
+      saveBackends,
+      reset: vi.fn()
+    });
+
+    await handler('settings', {
+      ui: {
+        custom: vi
+          .fn()
+          .mockResolvedValueOnce('presentation')
+          .mockResolvedValueOnce({
+            action: 'save',
+            scope: 'project',
+            config: { defaultMode: 'preview', tools: {} },
+            backends: DEFAULT_BACKEND_CONFIG
+          }),
+        notify
+      }
+    });
+
+    expect(save).toHaveBeenCalledWith('project', { defaultMode: 'preview', tools: {} });
+    expect(saveBackends).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Saved project presentation config'), 'info');
+  });
+
+  it('saves only backend overrides from the backend settings section', async () => {
+    let handler: any;
+    const save = vi.fn();
+    const saveBackends = vi.fn();
+    const pi = {
+      registerCommand: vi.fn((_name: string, command: any) => {
+        handler = command.handler;
+      })
+    };
+
+    registerWebAgentConfigCommands(pi as never, {
+      load: vi.fn().mockResolvedValue({
+        global: { path: '/global/config.json', exists: false },
+        project: { path: '/project/config.json', exists: false },
+        effectiveConfig: { defaultMode: 'compact', tools: {} },
+        effectiveBackends: DEFAULT_BACKEND_CONFIG
+      }),
+      save,
+      saveBackends,
+      reset: vi.fn()
+    });
+
+    await handler('settings', {
+      ui: {
+        custom: vi
+          .fn()
+          .mockResolvedValueOnce('backends')
+          .mockResolvedValueOnce({
+            action: 'save',
+            scope: 'project',
+            config: { defaultMode: 'compact', tools: {} },
+            backends: {
+              search: { provider: 'searxng', baseUrl: 'http://localhost:8080', fallback: 'duckduckgo' },
+              fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', fallback: 'http' },
+              headless: { provider: 'local-browser' }
+            }
+          }),
+        notify: vi.fn()
+      }
+    });
+
+    expect(save).not.toHaveBeenCalled();
+    expect(saveBackends).toHaveBeenCalledWith('project', {
+      search: { provider: 'searxng', baseUrl: 'http://localhost:8080', fallback: 'duckduckgo' },
+      fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', fallback: 'http' }
+    });
   });
 
   it('saves sparse project overrides from settings instead of copying inherited defaults', async () => {
@@ -399,22 +594,28 @@ describe('web-agent config commands', () => {
           rawConfig: { defaultMode: 'preview', tools: {} }
         },
         project: { path: '/project/config.json', exists: false },
-        effectiveConfig: { defaultMode: 'preview', tools: {} }
+        effectiveConfig: { defaultMode: 'preview', tools: {} },
+        effectiveBackends: DEFAULT_BACKEND_CONFIG
       }),
       save,
+      saveBackends: vi.fn(),
       reset: vi.fn()
     });
 
     await handler('settings', {
       ui: {
-        custom: vi.fn().mockResolvedValue({
-          action: 'save',
-          scope: 'project',
-          config: {
-            defaultMode: 'preview',
-            tools: { web_explore: { mode: 'verbose' } }
-          }
-        }),
+        custom: vi
+          .fn()
+          .mockResolvedValueOnce('presentation')
+          .mockResolvedValueOnce({
+            action: 'save',
+            scope: 'project',
+            config: {
+              defaultMode: 'preview',
+              tools: { web_explore: { mode: 'verbose' } }
+            },
+            backends: DEFAULT_BACKEND_CONFIG
+          }),
         notify
       }
     });
@@ -422,7 +623,7 @@ describe('web-agent config commands', () => {
     expect(save).toHaveBeenCalledWith('project', {
       tools: { web_explore: { mode: 'verbose' } }
     });
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Saved project config'), 'info');
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Saved project presentation config'), 'info');
   });
 
   it('resets the selected scope when the settings ui returns reset', async () => {

--- a/tests/presentation/config-store.test.ts
+++ b/tests/presentation/config-store.test.ts
@@ -6,6 +6,7 @@ import {
   getPresentationConfigPaths,
   loadPresentationConfigLayers,
   resetPresentationConfigScope,
+  saveBackendConfigScope,
   savePresentationConfigScope
 } from '../../src/presentation/config-store.js';
 
@@ -218,6 +219,31 @@ describe('presentation config store', () => {
       presentation: {
         tools: { web_search: { mode: 'verbose' } }
       }
+    });
+  });
+
+  it('saves backend overrides without dropping existing presentation config', async () => {
+    const { projectPath } = getPresentationConfigPaths({ homeDir, projectDir });
+
+    await savePresentationConfigScope({ homeDir, projectDir }, 'project', {
+      defaultMode: 'preview',
+      tools: { web_explore: { mode: 'verbose' } }
+    });
+
+    await saveBackendConfigScope({ homeDir, projectDir }, 'project', {
+      search: { provider: 'searxng', baseUrl: 'http://localhost:8080', fallback: 'duckduckgo' },
+      fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', fallback: 'http', apiKey: 'do-not-write' }
+    });
+
+    const parsed = JSON.parse(readFileSync(projectPath, 'utf8'));
+
+    expect(parsed.presentation).toEqual({
+      defaultMode: 'preview',
+      tools: { web_explore: { mode: 'verbose' } }
+    });
+    expect(parsed.backends).toEqual({
+      search: { provider: 'searxng', baseUrl: 'http://localhost:8080', fallback: 'duckduckgo' },
+      fetch: { provider: 'firecrawl', baseUrl: 'http://localhost:3002', fallback: 'http' }
     });
   });
 


### PR DESCRIPTION
Adds a Backends section under `/web-agent settings` so SearXNG and Firecrawl can be configured without hand-editing JSON.

Also fixes config saving so presentation/backend sections don't wipe each other, and keeps Firecrawl keys out of saved config.

Checked with npm test, npm run lint, npm run build.
